### PR TITLE
fix(review-ui): deduplicate draft changes and fix text truncation

### DIFF
--- a/eigen/internal/server/ui/app.js
+++ b/eigen/internal/server/ui/app.js
@@ -579,7 +579,15 @@ async function pollOnce() {
   try {
     const res = await fetch('/api/changes?status=draft');
     if (!res.ok) { hideReviewPanel(); schedulePoll(); return; }
-    const drafts = await res.json();
+    const allDrafts = await res.json();
+    // Same change file appears once per worktree — deduplicate by module_path+filename,
+    // preferring the main/primary worktree so approve/reject targets the canonical copy.
+    const seen = new Map();
+    for (const d of allDrafts) {
+      const key = (d.module_path || '') + '/' + (d.filename || '');
+      if (!seen.has(key) || !d.worktree || d.worktree === 'main') seen.set(key, d);
+    }
+    const drafts = Array.from(seen.values());
     if (drafts.length === 0) { hideReviewPanel(); schedulePoll(); return; }
     // Don't interrupt if the panel is already open.
     const panel = document.getElementById('review-panel');

--- a/eigen/internal/server/ui/style.css
+++ b/eigen/internal/server/ui/style.css
@@ -242,6 +242,7 @@ html, body {
   font-family: inherit;
   line-height: 1.6;
   color: var(--text);
+  overflow: visible;
 }
 
 /* AC list */
@@ -600,6 +601,8 @@ html, body {
   color: var(--text);
   white-space: pre-wrap;
   word-break: break-word;
+  overflow: visible;
+  line-height: 1.6;
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 6px;


### PR DESCRIPTION
## Summary

- **Fixes #34** — Review UI showed the same change file once per worktree (e.g. 3 actual drafts rendered as 12 items). The `/api/changes?status=draft` endpoint returns each change once per worktree that contains it, because all worktrees share the same `specs/` directory. The poll loop now deduplicates by `module_path + filename`, keeping the `main`/primary worktree entry so approve/reject targets the canonical copy.

- **Fixes #36** — Long `behavior` and `description` fields were truncated in both the module detail view and the review panel. `<pre>` elements have a browser-default `overflow: auto` which can clip tall content vertically. Added `overflow: visible` to `.pre-text` and `.review-field-text` in `style.css`, and added `line-height: 1.6` to `.review-field-text` for consistency with the detail view.

## Changed files

- `eigen/internal/server/ui/app.js` — deduplication logic in `pollOnce`
- `eigen/internal/server/ui/style.css` — `overflow: visible` + `line-height` on pre-text classes

## Test plan

- [ ] Start `eigen serve` with multiple git worktrees active; confirm pending review list shows each change once, not once per worktree
- [ ] Open a module with a multi-paragraph `behavior` field; confirm the full text renders without clipping in both the detail view and the review panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)