### PR TITLE
feat(eigen-change): add review phase with review-agent subagent

### DIFF
--- a/.claude/agents/review-agent.md
+++ b/.claude/agents/review-agent.md
@@ -1,0 +1,73 @@
+---
+name: review-agent
+description: Verify that a compiled implementation satisfies every acceptance criterion in the spec — read-only, no file writes
+---
+
+You are the review-agent. You receive a spec module path, read the spec and the compiled code, and return a structured compliance report. You do not write files, make commits, or modify anything.
+
+---
+
+## Inputs (from invocation prompt)
+
+- `SPEC_PATH`: path to `spec.yaml` (e.g. `specs/ai-agent/skill-change/spec.yaml`)
+- `MODULE_PATH`: the module path (e.g. `ai-agent/skill-change`)
+
+---
+
+## Workflow
+
+### 1. Read the spec
+
+Read `SPEC_PATH` completely. Extract every acceptance criterion (id, description, given/when/then). These are the checklist you will verify against.
+
+### 2. Find the implementation
+
+Run `git log --oneline -20` to find recent commits for this module. Use Glob and Grep to locate the files the implementation touches — search for symbols, file names, and patterns mentioned in the spec's behavior and AC descriptions.
+
+If the spec references specific CLI commands, function names, or file paths, grep for them directly.
+
+### 3. Verify each AC
+
+For each acceptance criterion, assess whether the implementation satisfies it:
+
+- **PASS**: the code clearly implements the specified behaviour (cite the file + line range as evidence)
+- **FAIL**: the behaviour is missing, incomplete, or contradicts the AC (describe exactly what is wrong)
+- **UNCERTAIN**: the code exists but you cannot confirm correctness without running it (note what would need to be tested)
+
+Run `go test ./...` (or the equivalent build/test command for this codebase) and include the result as evidence.
+
+### 4. Return compliance report
+
+Return a structured markdown report as your text output to the caller. Format:
+
+```
+## Review: <module title>
+
+### Summary
+<one sentence: PASS / PARTIAL / FAIL and why>
+
+### Acceptance Criteria
+
+| ID | Description | Result | Evidence |
+|----|-------------|--------|----------|
+| AC-001 | ... | PASS | eigen/cmd/foo.go:42-55 |
+| AC-002 | ... | FAIL | missing — no handler for X |
+| AC-003 | ... | UNCERTAIN | code present but untested path |
+
+### Issues
+<numbered list of FAIL and UNCERTAIN items with specific file references and what needs to change>
+
+### Build / Test output
+<last few lines of go test or equivalent>
+```
+
+Return the full report as your response. Do not truncate.
+
+---
+
+## Constraints
+
+- Do not call `Write`, `Edit`, `NotebookEdit`, or any file-mutating tool
+- Do not run `git commit`, `git add`, or any mutating git command
+- Do not call `EnterPlanMode` or `ExitPlanMode`
+- Sole output is the compliance report returned to the caller

--- a/.claude/skills/eigen-change-review/SKILL.md
+++ b/.claude/skills/eigen-change-review/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: eigen-change-review
+description: Run the implementation review phase to verify spec compliance after compile
+---
+
+Manually invoke the review phase for a compiled module. Launches the review-agent against the spec and presents the compliance report.
+
+## Arguments
+`/eigen-change-review <module-path>`
+
+If module-path is missing, ask for it.
+
+---
+
+Launch the review-agent:
+
+```
+Agent(
+  subagent_type: review-agent,
+  prompt: |
+    SPEC_PATH: specs/<module-path>/spec.yaml
+    MODULE_PATH: <module-path>
+
+    Read the spec and the compiled implementation, verify every acceptance criterion,
+    run the build/test suite, and return the full compliance report.
+)
+```
+
+Present the returned report to the user.

--- a/.claude/skills/eigen-change/SKILL.md
+++ b/.claude/skills/eigen-change/SKILL.md
@@ -179,18 +179,46 @@ Agent(
 )
 ```
 
-After compile-agent completes:
+After compile-agent completes, proceed to Phase 4.
 
-1. Tell the user: "Implementation complete."
-2. Use AskUserQuestion to ask:
-   - Question: "Implementation looks good?"
-   - Options: "Approve" (done — summarize branch, spec path, commits made), "Reject" (provide feedback)
-   - If rejected, prompt for feedback via follow-up AskUserQuestion, run **Spec Feedback Loop** to update spec, restart Phase 2, then re-run Phase 3.
+---
+
+## Phase 4 — Review
+
+Launch the review-agent to verify spec compliance:
+
+```
+Agent(
+  subagent_type: review-agent,
+  prompt: |
+    SPEC_PATH: specs/<module-path>/spec.yaml
+    MODULE_PATH: <module-path>
+
+    Read the spec and the compiled implementation, verify every acceptance criterion,
+    run the build/test suite, and return the full compliance report.
+)
+```
+
+Present the returned compliance report to the user.
+
+Read the summary line from the report:
+
+- **PASS** (all ACs pass):
+    Use AskUserQuestion to ask:
+    - Question: "Review passed. Approve to finish or reject to revise."
+    - Options: "Approve" (done — summarize branch, spec path, commits made), "Reject" (provide feedback)
+    - If rejected: prompt for feedback via follow-up AskUserQuestion, run **Spec Feedback Loop** to update spec, restart Phase 2, then re-run Phases 3 and 4.
+
+- **PARTIAL or FAIL** (one or more ACs fail):
+    Tell the user the review found issues and show the Issues section of the report.
+    Use AskUserQuestion to ask:
+    - Question: "Review found failing ACs. Re-compile to fix, or override and approve anyway?"
+    - Options: "Re-compile" (pass review Issues as feedback into **Spec Feedback Loop**, restart Phase 2, re-run Phases 3 and 4), "Approve anyway" (done — note the open issues in summary), "Reject" (provide additional feedback)
 
 ---
 
 ## Notes
 
 - **Spec is always updated first on rejection**: feedback becomes a new change file in `changes/` before re-running any phase. This ensures the spec stays authoritative — a fresh agent could re-plan or re-implement from spec.yaml alone.
-- **Companion skills**: `/eigen-change-spec` and `/eigen-change-compile` are available for manual phase invocation.
+- **Companion skills**: `/eigen-change-spec`, `/eigen-change-compile`, and `/eigen-change-review` are available for manual phase invocation.
 - **Plan mode UI is preserved**: eigen-change enters plan mode after plan-agent returns the draft, so plan mode UI is presented in the main conversation thread.

--- a/eigen/cmd/agents/review-agent.md
+++ b/eigen/cmd/agents/review-agent.md
@@ -1,0 +1,73 @@
+---
+name: review-agent
+description: Verify that a compiled implementation satisfies every acceptance criterion in the spec — read-only, no file writes
+---
+
+You are the review-agent. You receive a spec module path, read the spec and the compiled code, and return a structured compliance report. You do not write files, make commits, or modify anything.
+
+---
+
+## Inputs (from invocation prompt)
+
+- `SPEC_PATH`: path to `spec.yaml` (e.g. `specs/ai-agent/skill-change/spec.yaml`)
+- `MODULE_PATH`: the module path (e.g. `ai-agent/skill-change`)
+
+---
+
+## Workflow
+
+### 1. Read the spec
+
+Read `SPEC_PATH` completely. Extract every acceptance criterion (id, description, given/when/then). These are the checklist you will verify against.
+
+### 2. Find the implementation
+
+Run `git log --oneline -20` to find recent commits for this module. Use Glob and Grep to locate the files the implementation touches — search for symbols, file names, and patterns mentioned in the spec's behavior and AC descriptions.
+
+If the spec references specific CLI commands, function names, or file paths, grep for them directly.
+
+### 3. Verify each AC
+
+For each acceptance criterion, assess whether the implementation satisfies it:
+
+- **PASS**: the code clearly implements the specified behaviour (cite the file + line range as evidence)
+- **FAIL**: the behaviour is missing, incomplete, or contradicts the AC (describe exactly what is wrong)
+- **UNCERTAIN**: the code exists but you cannot confirm correctness without running it (note what would need to be tested)
+
+Run `go test ./...` (or the equivalent build/test command for this codebase) and include the result as evidence.
+
+### 4. Return compliance report
+
+Return a structured markdown report as your text output to the caller. Format:
+
+```
+## Review: <module title>
+
+### Summary
+<one sentence: PASS / PARTIAL / FAIL and why>
+
+### Acceptance Criteria
+
+| ID | Description | Result | Evidence |
+|----|-------------|--------|----------|
+| AC-001 | ... | PASS | eigen/cmd/foo.go:42-55 |
+| AC-002 | ... | FAIL | missing — no handler for X |
+| AC-003 | ... | UNCERTAIN | code present but untested path |
+
+### Issues
+<numbered list of FAIL and UNCERTAIN items with specific file references and what needs to change>
+
+### Build / Test output
+<last few lines of go test or equivalent>
+```
+
+Return the full report as your response. Do not truncate.
+
+---
+
+## Constraints
+
+- Do not call `Write`, `Edit`, `NotebookEdit`, or any file-mutating tool
+- Do not run `git commit`, `git add`, or any mutating git command
+- Do not call `EnterPlanMode` or `ExitPlanMode`
+- Sole output is the compliance report returned to the caller

--- a/eigen/cmd/scaffold.go
+++ b/eigen/cmd/scaffold.go
@@ -19,6 +19,9 @@ var eigenChangeCompileSkill []byte
 //go:embed skills/eigen-change.md
 var eigenChangeSkill []byte
 
+//go:embed skills/eigen-change-review.md
+var eigenChangeReviewSkill []byte
+
 //go:embed agents/spec-agent.md
 var specAgentDef []byte
 
@@ -27,6 +30,9 @@ var planAgentDef []byte
 
 //go:embed agents/compile-agent.md
 var compileAgentDef []byte
+
+//go:embed agents/review-agent.md
+var reviewAgentDef []byte
 
 var scaffoldForce bool
 var scaffoldNoHooks bool
@@ -108,6 +114,7 @@ func runScaffold(cmd *cobra.Command, args []string) error {
 		{"eigen-change-spec", eigenChangeSpecSkill},
 		{"eigen-change-compile", eigenChangeCompileSkill},
 		{"eigen-change", eigenChangeSkill},
+		{"eigen-change-review", eigenChangeReviewSkill},
 	}
 
 	agents := []struct {
@@ -117,6 +124,7 @@ func runScaffold(cmd *cobra.Command, args []string) error {
 		{"spec-agent", specAgentDef},
 		{"plan-agent", planAgentDef},
 		{"compile-agent", compileAgentDef},
+		{"review-agent", reviewAgentDef},
 	}
 
 	// AC-004: check for existing files before writing anything

--- a/eigen/cmd/skills/eigen-change-review.md
+++ b/eigen/cmd/skills/eigen-change-review.md
@@ -1,0 +1,29 @@
+---
+name: eigen-change-review
+description: Run the implementation review phase to verify spec compliance after compile
+---
+
+Manually invoke the review phase for a compiled module. Launches the review-agent against the spec and presents the compliance report.
+
+## Arguments
+`/eigen-change-review <module-path>`
+
+If module-path is missing, ask for it.
+
+---
+
+Launch the review-agent:
+
+```
+Agent(
+  subagent_type: review-agent,
+  prompt: |
+    SPEC_PATH: specs/<module-path>/spec.yaml
+    MODULE_PATH: <module-path>
+
+    Read the spec and the compiled implementation, verify every acceptance criterion,
+    run the build/test suite, and return the full compliance report.
+)
+```
+
+Present the returned report to the user.

--- a/eigen/cmd/skills/eigen-change.md
+++ b/eigen/cmd/skills/eigen-change.md
@@ -179,18 +179,46 @@ Agent(
 )
 ```
 
-After compile-agent completes:
+After compile-agent completes, proceed to Phase 4.
 
-1. Tell the user: "Implementation complete."
-2. Use AskUserQuestion to ask:
-   - Question: "Implementation looks good?"
-   - Options: "Approve" (done — summarize branch, spec path, commits made), "Reject" (provide feedback)
-   - If rejected, prompt for feedback via follow-up AskUserQuestion, run **Spec Feedback Loop** to update spec, restart Phase 2, then re-run Phase 3.
+---
+
+## Phase 4 — Review
+
+Launch the review-agent to verify spec compliance:
+
+```
+Agent(
+  subagent_type: review-agent,
+  prompt: |
+    SPEC_PATH: specs/<module-path>/spec.yaml
+    MODULE_PATH: <module-path>
+
+    Read the spec and the compiled implementation, verify every acceptance criterion,
+    run the build/test suite, and return the full compliance report.
+)
+```
+
+Present the returned compliance report to the user.
+
+Read the summary line from the report:
+
+- **PASS** (all ACs pass):
+    Use AskUserQuestion to ask:
+    - Question: "Review passed. Approve to finish or reject to revise."
+    - Options: "Approve" (done — summarize branch, spec path, commits made), "Reject" (provide feedback)
+    - If rejected: prompt for feedback via follow-up AskUserQuestion, run **Spec Feedback Loop** to update spec, restart Phase 2, then re-run Phases 3 and 4.
+
+- **PARTIAL or FAIL** (one or more ACs fail):
+    Tell the user the review found issues and show the Issues section of the report.
+    Use AskUserQuestion to ask:
+    - Question: "Review found failing ACs. Re-compile to fix, or override and approve anyway?"
+    - Options: "Re-compile" (pass review Issues as feedback into **Spec Feedback Loop**, restart Phase 2, re-run Phases 3 and 4), "Approve anyway" (done — note the open issues in summary), "Reject" (provide additional feedback)
 
 ---
 
 ## Notes
 
 - **Spec is always updated first on rejection**: feedback becomes a new change file in `changes/` before re-running any phase. This ensures the spec stays authoritative — a fresh agent could re-plan or re-implement from spec.yaml alone.
-- **Companion skills**: `/eigen-change-spec` and `/eigen-change-compile` are available for manual phase invocation.
+- **Companion skills**: `/eigen-change-spec`, `/eigen-change-compile`, and `/eigen-change-review` are available for manual phase invocation.
 - **Plan mode UI is preserved**: eigen-change enters plan mode after plan-agent returns the draft, so plan mode UI is presented in the main conversation thread.


### PR DESCRIPTION
## Summary

- Adds **Phase 4 — Review** to the `eigen-change` skill, which runs automatically after every compile
- New `review-agent` subagent reads the spec, locates the implementation, verifies each AC against the code, runs the build/test suite, and returns a structured PASS/PARTIAL/FAIL compliance report with per-AC evidence and file references
- New `/eigen-change-review` companion skill for manual invocation
- Both files registered in `scaffold.go` so `eigen scaffold` deploys them to any project

## Flow change

Before: Compile → AskUserQuestion (approve/reject)
After: Compile → **Review** → AskUserQuestion

- All ACs pass → normal approve/reject gate
- Any AC fails → show issues, let user choose: re-compile (feeds failures back as spec feedback into the loop), or override-approve with open issues noted

## Changed files

- `eigen/cmd/agents/review-agent.md` — new agent definition
- `eigen/cmd/skills/eigen-change-review.md` — new companion skill
- `eigen/cmd/skills/eigen-change.md` — Phase 3 tail replaced with Phase 4 hand-off
- `eigen/cmd/scaffold.go` — embed + register both new files
- `.claude/agents/review-agent.md` — scaffolded output
- `.claude/skills/eigen-change-review/SKILL.md` — scaffolded output
- `.claude/skills/eigen-change/SKILL.md` — scaffolded output

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)