### PR TITLE
skill-change: new branch from main, E2E review, auto PR creation

### DIFF
--- a/.claude/agents/review-agent.md
+++ b/.claude/agents/review-agent.md
@@ -26,7 +26,17 @@ Run `git log --oneline -20` to find recent commits for this module. Use Glob and
 
 If the spec references specific CLI commands, function names, or file paths, grep for them directly.
 
-### 3. Verify each AC
+### 3. Build and exercise the environment
+
+Before evaluating any AC:
+
+1. Build the binary: run `go build ./...` from the `eigen/` subdirectory of the repo root. Record PASS or FAIL.
+2. If the spec involves `eigen serve`, the spec-navigator, or any HTTP API subsystem:
+   - Start `eigen serve &` and poll `http://localhost:7171` until HTTP 200 is returned (30-second timeout).
+   - Exercise relevant API endpoints with curl and record the responses as evidence.
+3. Run `go test ./...` and capture the output.
+
+### 4. Verify each AC
 
 For each acceptance criterion, assess whether the implementation satisfies it:
 
@@ -34,9 +44,9 @@ For each acceptance criterion, assess whether the implementation satisfies it:
 - **FAIL**: the behaviour is missing, incomplete, or contradicts the AC (describe exactly what is wrong)
 - **UNCERTAIN**: the code exists but you cannot confirm correctness without running it (note what would need to be tested)
 
-Run `go test ./...` (or the equivalent build/test command for this codebase) and include the result as evidence.
+Label each result as `LIVE` (verified through live execution) or `STATIC` (verified through static source analysis only).
 
-### 4. Return compliance report
+### 5. Return compliance report
 
 Return a structured markdown report as your text output to the caller. Format:
 
@@ -46,13 +56,18 @@ Return a structured markdown report as your text output to the caller. Format:
 ### Summary
 <one sentence: PASS / PARTIAL / FAIL and why>
 
+### Environment
+- Binary build: PASS / FAIL
+- eigen serve started: YES / NO / N/A
+- Endpoints exercised: <list or N/A>
+
 ### Acceptance Criteria
 
-| ID | Description | Result | Evidence |
-|----|-------------|--------|----------|
-| AC-001 | ... | PASS | eigen/cmd/foo.go:42-55 |
-| AC-002 | ... | FAIL | missing — no handler for X |
-| AC-003 | ... | UNCERTAIN | code present but untested path |
+| ID | Description | Result | Verification | Evidence |
+|----|-------------|--------|--------------|----------|
+| AC-001 | ... | PASS | LIVE | eigen/cmd/foo.go:42-55 |
+| AC-002 | ... | FAIL | STATIC | missing — no handler for X |
+| AC-003 | ... | UNCERTAIN | STATIC | code present but untested path |
 
 ### Issues
 <numbered list of FAIL and UNCERTAIN items with specific file references and what needs to change>

--- a/.claude/skills/eigen-change-review/SKILL.md
+++ b/.claude/skills/eigen-change-review/SKILL.md
@@ -21,8 +21,18 @@ Agent(
     SPEC_PATH: specs/<module-path>/spec.yaml
     MODULE_PATH: <module-path>
 
-    Read the spec and the compiled implementation, verify every acceptance criterion,
-    run the build/test suite, and return the full compliance report.
+    Read the spec and the compiled implementation. Before evaluating correctness:
+    1. Build the binary: run `go build ./...` from the `eigen/` subdirectory of the repo root.
+    2. If the change involves the spec-navigator, serve, or any HTTP API subsystem:
+       - Start `eigen serve &` and wait for it to be ready (poll http://localhost:7171 until HTTP 200).
+       - Exercise relevant API endpoints with curl (e.g. `curl -s http://localhost:7171/api/modules`).
+       - Fetch or check relevant web pages where browser tools are available.
+    3. For all other changes, still build the binary and run `go test ./...`.
+
+    Verify every acceptance criterion. In the compliance report, clearly label each AC as
+    verified through live execution (LIVE) or static analysis only (STATIC).
+
+    Return the full compliance report.
 )
 ```
 

--- a/.claude/skills/eigen-change/SKILL.md
+++ b/.claude/skills/eigen-change/SKILL.md
@@ -16,11 +16,21 @@ If description is missing, ask what the user wants to build.
 
 Before starting, collect context that all agents will need:
 
-```bash
-git branch --show-current
-```
+**Branch setup:**
+- If the invocation args include `--branch <name>`, set `BRANCH=<name>` and skip branch creation.
+- If the user explicitly states they want to continue on the current branch, run `git branch --show-current`, store as `BRANCH`, and skip branch creation.
+- Otherwise, derive a branch name from the module path or description (replace `/` with `-`, prefix with `feat/`, e.g. `feat/skill-change-branch-from-main`), then:
+  ```bash
+  git fetch origin main
+  git checkout -b <derived-branch-name> origin/main
+  ```
+  Store the new branch name as `BRANCH`.
 
-Store as `BRANCH`.
+Capture `WORKTREE`:
+```bash
+basename "$(git rev-parse --show-toplevel)"
+```
+Store as `WORKTREE`.
 
 Ask the user which module path to use (e.g. `ai-agent/skill-change`) or derive it from the description if obvious.
 
@@ -194,8 +204,18 @@ Agent(
     SPEC_PATH: specs/<module-path>/spec.yaml
     MODULE_PATH: <module-path>
 
-    Read the spec and the compiled implementation, verify every acceptance criterion,
-    run the build/test suite, and return the full compliance report.
+    Read the spec and the compiled implementation. Before evaluating correctness:
+    1. Build the binary: run `go build ./...` from the `eigen/` subdirectory of the repo root.
+    2. If the change involves the spec-navigator, serve, or any HTTP API subsystem:
+       - Start `eigen serve &` and wait for it to be ready (poll http://localhost:7171 until HTTP 200).
+       - Exercise relevant API endpoints with curl (e.g. `curl -s http://localhost:7171/api/modules`).
+       - Fetch or check relevant web pages where browser tools are available.
+    3. For all other changes, still build the binary and run `go test ./...`.
+
+    Verify every acceptance criterion. In the compliance report, clearly label each AC as
+    verified through live execution (LIVE) or static analysis only (STATIC).
+
+    Return the full compliance report.
 )
 ```
 

--- a/.claude/skills/eigen-change/SKILL.md
+++ b/.claude/skills/eigen-change/SKILL.md
@@ -226,14 +226,26 @@ Read the summary line from the report:
 - **PASS** (all ACs pass):
     Use AskUserQuestion to ask:
     - Question: "Review passed. Approve to finish or reject to revise."
-    - Options: "Approve" (done — summarize branch, spec path, commits made), "Reject" (provide feedback)
+    - Options: "Approve", "Reject" (provide feedback)
+    - If approved: create a GitHub PR:
+      ```bash
+      gh pr create --title "<module>: <change summary>" --body "$(cat <<'EOF'
+      ## Summary
+      - Spec: specs/<module-path>/spec.yaml
+      - ACs implemented: <list AC IDs from spec>
+
+      🤖 Generated with [Claude Code](https://claude.com/claude-code)
+      EOF
+      )"
+      ```
+      Capture the PR URL from stdout and present it to the user as the final output.
     - If rejected: prompt for feedback via follow-up AskUserQuestion, run **Spec Feedback Loop** to update spec, restart Phase 2, then re-run Phases 3 and 4.
 
 - **PARTIAL or FAIL** (one or more ACs fail):
     Tell the user the review found issues and show the Issues section of the report.
     Use AskUserQuestion to ask:
     - Question: "Review found failing ACs. Re-compile to fix, or override and approve anyway?"
-    - Options: "Re-compile" (pass review Issues as feedback into **Spec Feedback Loop**, restart Phase 2, re-run Phases 3 and 4), "Approve anyway" (done — note the open issues in summary), "Reject" (provide additional feedback)
+    - Options: "Re-compile" (pass review Issues as feedback into **Spec Feedback Loop**, restart Phase 2, re-run Phases 3 and 4), "Approve anyway" (create PR and note open issues in summary), "Reject" (provide additional feedback)
 
 ---
 

--- a/eigen/cmd/agents/review-agent.md
+++ b/eigen/cmd/agents/review-agent.md
@@ -26,7 +26,17 @@ Run `git log --oneline -20` to find recent commits for this module. Use Glob and
 
 If the spec references specific CLI commands, function names, or file paths, grep for them directly.
 
-### 3. Verify each AC
+### 3. Build and exercise the environment
+
+Before evaluating any AC:
+
+1. Build the binary: run `go build ./...` from the `eigen/` subdirectory of the repo root. Record PASS or FAIL.
+2. If the spec involves `eigen serve`, the spec-navigator, or any HTTP API subsystem:
+   - Start `eigen serve &` and poll `http://localhost:7171` until HTTP 200 is returned (30-second timeout).
+   - Exercise relevant API endpoints with curl and record the responses as evidence.
+3. Run `go test ./...` and capture the output.
+
+### 4. Verify each AC
 
 For each acceptance criterion, assess whether the implementation satisfies it:
 
@@ -34,9 +44,9 @@ For each acceptance criterion, assess whether the implementation satisfies it:
 - **FAIL**: the behaviour is missing, incomplete, or contradicts the AC (describe exactly what is wrong)
 - **UNCERTAIN**: the code exists but you cannot confirm correctness without running it (note what would need to be tested)
 
-Run `go test ./...` (or the equivalent build/test command for this codebase) and include the result as evidence.
+Label each result as `LIVE` (verified through live execution) or `STATIC` (verified through static source analysis only).
 
-### 4. Return compliance report
+### 5. Return compliance report
 
 Return a structured markdown report as your text output to the caller. Format:
 
@@ -46,13 +56,18 @@ Return a structured markdown report as your text output to the caller. Format:
 ### Summary
 <one sentence: PASS / PARTIAL / FAIL and why>
 
+### Environment
+- Binary build: PASS / FAIL
+- eigen serve started: YES / NO / N/A
+- Endpoints exercised: <list or N/A>
+
 ### Acceptance Criteria
 
-| ID | Description | Result | Evidence |
-|----|-------------|--------|----------|
-| AC-001 | ... | PASS | eigen/cmd/foo.go:42-55 |
-| AC-002 | ... | FAIL | missing — no handler for X |
-| AC-003 | ... | UNCERTAIN | code present but untested path |
+| ID | Description | Result | Verification | Evidence |
+|----|-------------|--------|--------------|----------|
+| AC-001 | ... | PASS | LIVE | eigen/cmd/foo.go:42-55 |
+| AC-002 | ... | FAIL | STATIC | missing — no handler for X |
+| AC-003 | ... | UNCERTAIN | STATIC | code present but untested path |
 
 ### Issues
 <numbered list of FAIL and UNCERTAIN items with specific file references and what needs to change>

--- a/eigen/cmd/skills/eigen-change-review.md
+++ b/eigen/cmd/skills/eigen-change-review.md
@@ -21,8 +21,18 @@ Agent(
     SPEC_PATH: specs/<module-path>/spec.yaml
     MODULE_PATH: <module-path>
 
-    Read the spec and the compiled implementation, verify every acceptance criterion,
-    run the build/test suite, and return the full compliance report.
+    Read the spec and the compiled implementation. Before evaluating correctness:
+    1. Build the binary: run `go build ./...` from the `eigen/` subdirectory of the repo root.
+    2. If the change involves the spec-navigator, serve, or any HTTP API subsystem:
+       - Start `eigen serve &` and wait for it to be ready (poll http://localhost:7171 until HTTP 200).
+       - Exercise relevant API endpoints with curl (e.g. `curl -s http://localhost:7171/api/modules`).
+       - Fetch or check relevant web pages where browser tools are available.
+    3. For all other changes, still build the binary and run `go test ./...`.
+
+    Verify every acceptance criterion. In the compliance report, clearly label each AC as
+    verified through live execution (LIVE) or static analysis only (STATIC).
+
+    Return the full compliance report.
 )
 ```
 

--- a/eigen/cmd/skills/eigen-change.md
+++ b/eigen/cmd/skills/eigen-change.md
@@ -16,11 +16,21 @@ If description is missing, ask what the user wants to build.
 
 Before starting, collect context that all agents will need:
 
-```bash
-git branch --show-current
-```
+**Branch setup:**
+- If the invocation args include `--branch <name>`, set `BRANCH=<name>` and skip branch creation.
+- If the user explicitly states they want to continue on the current branch, run `git branch --show-current`, store as `BRANCH`, and skip branch creation.
+- Otherwise, derive a branch name from the module path or description (replace `/` with `-`, prefix with `feat/`, e.g. `feat/skill-change-branch-from-main`), then:
+  ```bash
+  git fetch origin main
+  git checkout -b <derived-branch-name> origin/main
+  ```
+  Store the new branch name as `BRANCH`.
 
-Store as `BRANCH`.
+Capture `WORKTREE`:
+```bash
+basename "$(git rev-parse --show-toplevel)"
+```
+Store as `WORKTREE`.
 
 Ask the user which module path to use (e.g. `ai-agent/skill-change`) or derive it from the description if obvious.
 
@@ -194,8 +204,18 @@ Agent(
     SPEC_PATH: specs/<module-path>/spec.yaml
     MODULE_PATH: <module-path>
 
-    Read the spec and the compiled implementation, verify every acceptance criterion,
-    run the build/test suite, and return the full compliance report.
+    Read the spec and the compiled implementation. Before evaluating correctness:
+    1. Build the binary: run `go build ./...` from the `eigen/` subdirectory of the repo root.
+    2. If the change involves the spec-navigator, serve, or any HTTP API subsystem:
+       - Start `eigen serve &` and wait for it to be ready (poll http://localhost:7171 until HTTP 200).
+       - Exercise relevant API endpoints with curl (e.g. `curl -s http://localhost:7171/api/modules`).
+       - Fetch or check relevant web pages where browser tools are available.
+    3. For all other changes, still build the binary and run `go test ./...`.
+
+    Verify every acceptance criterion. In the compliance report, clearly label each AC as
+    verified through live execution (LIVE) or static analysis only (STATIC).
+
+    Return the full compliance report.
 )
 ```
 

--- a/eigen/cmd/skills/eigen-change.md
+++ b/eigen/cmd/skills/eigen-change.md
@@ -226,14 +226,26 @@ Read the summary line from the report:
 - **PASS** (all ACs pass):
     Use AskUserQuestion to ask:
     - Question: "Review passed. Approve to finish or reject to revise."
-    - Options: "Approve" (done — summarize branch, spec path, commits made), "Reject" (provide feedback)
+    - Options: "Approve", "Reject" (provide feedback)
+    - If approved: create a GitHub PR:
+      ```bash
+      gh pr create --title "<module>: <change summary>" --body "$(cat <<'EOF'
+      ## Summary
+      - Spec: specs/<module-path>/spec.yaml
+      - ACs implemented: <list AC IDs from spec>
+
+      🤖 Generated with [Claude Code](https://claude.com/claude-code)
+      EOF
+      )"
+      ```
+      Capture the PR URL from stdout and present it to the user as the final output.
     - If rejected: prompt for feedback via follow-up AskUserQuestion, run **Spec Feedback Loop** to update spec, restart Phase 2, then re-run Phases 3 and 4.
 
 - **PARTIAL or FAIL** (one or more ACs fail):
     Tell the user the review found issues and show the Issues section of the report.
     Use AskUserQuestion to ask:
     - Question: "Review found failing ACs. Re-compile to fix, or override and approve anyway?"
-    - Options: "Re-compile" (pass review Issues as feedback into **Spec Feedback Loop**, restart Phase 2, re-run Phases 3 and 4), "Approve anyway" (done — note the open issues in summary), "Reject" (provide additional feedback)
+    - Options: "Re-compile" (pass review Issues as feedback into **Spec Feedback Loop**, restart Phase 2, re-run Phases 3 and 4), "Approve anyway" (create PR and note open issues in summary), "Reject" (provide additional feedback)
 
 ---
 

--- a/specs/ai-agent/skill-change/changes/011_initial.yaml
+++ b/specs/ai-agent/skill-change/changes/011_initial.yaml
@@ -1,0 +1,74 @@
+format: eigen/v1
+id: chg-011
+sequence: 11
+timestamp: 2026-04-18T14:06:56Z
+author: alexander
+type: updated
+summary: New-branch-from-main at setup; E2E environment verification in review phase
+reason: |
+  Two workflow correctness improvements:
+
+  1. The skill currently continues on whatever branch is checked out when invoked. This
+     risks polluting main or an unrelated feature branch with spec/implementation commits.
+     The skill should always start fresh from an up-to-date main branch so every run is
+     isolated and traceable.
+
+  2. Phase 4 review is limited to static code reading. Real regressions are only caught by
+     running the actual binary against live API endpoints and rendered pages. The review
+     phase must build the binary and exercise the local environment to verify behavior, not
+     just reason about source text.
+changes:
+  behavior:
+    - op: replace
+      old: "The /change skill orchestrates spec -> plan -> compile. At setup it captures both\nBRANCH (from git branch --show-current) and WORKTREE (the worktree name, derived\nfrom the basename of `git rev-parse --show-toplevel`). WORKTREE is threaded into all\nHTTP API calls to the eigen serve API as a ?worktree= query parameter so modules are\ncorrectly disambiguated when the same module path exists in multiple worktrees."
+      new: "The /change skill orchestrates spec -> plan -> compile. At setup it fetches the\nlatest main branch (`git fetch origin main`) and creates a new feature branch from it\n(`git checkout -b <feature-branch> origin/main`). The skill does NOT continue on the\ncurrently checked-out branch unless the user explicitly passes a flag (--branch) or\nexplicitly instructs it to do so. The branch name is derived from the module path or\nfeature description (e.g. `feat/skill-change-branch-from-main`). Setup also captures\nBRANCH (the new branch name) and WORKTREE (the worktree name, derived from the basename\nof `git rev-parse --show-toplevel`). WORKTREE is threaded into all HTTP API calls to the\neigen serve API as a ?worktree= query parameter so modules are correctly disambiguated\nwhen the same module path exists in multiple worktrees."
+    - op: append
+      text: |
+
+        Phase 4 review goes beyond static code analysis. The review-agent is instructed to
+        start up as much of the local environment as possible before evaluating correctness.
+        This includes: building the binary (`go build ./...` from the `eigen/` directory),
+        starting the spec-navigator web server if the change involves the serve/navigator
+        subsystem (`eigen serve &` and waiting for it to be ready), and then verifying
+        behavior by exercising relevant API endpoints (curl) and web pages (fetch or browser
+        tools if available). The review-agent reports which environment components it was
+        able to start and which acceptance criteria were verified through live execution
+        versus static analysis only.
+  acceptance_criteria:
+    - id: AC-001
+      description: |
+        `change` skill can be invoked with feature description and optional short-name hint.
+        At setup the skill fetches origin/main, creates a new feature branch from it, and
+        calls spec-subagent with the description. The skill does NOT continue on the current
+        branch unless the user passes --branch or explicitly instructs it to do so.
+      given: A user invokes /change with a feature description
+      when: The skill starts execution
+      then: |
+        The skill runs `git fetch origin main` then `git checkout -b <feature-branch> origin/main`,
+        stores the new branch name as BRANCH, and launches spec-agent with the description.
+    - id: AC-019
+      description: |
+        At setup, if the user has passed a --branch <name> flag or has explicitly stated they
+        want to continue on the current branch, the skill skips branch creation and uses the
+        existing branch. Otherwise branch creation from origin/main is always performed.
+      given: A user invokes /change without a --branch flag
+      when: The Setup section runs
+      then: |
+        A new branch is created from origin/main; the current branch is not used.
+        If --branch is passed or the user explicitly requests the current branch, branch
+        creation is skipped and BRANCH is set to the existing branch name.
+    - id: AC-020
+      description: |
+        Phase 4 review-agent builds the binary and starts any applicable local services
+        before evaluating correctness. It does not rely solely on static source analysis.
+        For changes involving the spec-navigator or serve subsystem, the agent starts
+        `eigen serve` and waits for it to be ready before exercising API endpoints.
+        The compliance report must state which ACs were verified through live execution
+        vs. static analysis only.
+      given: compile-agent has completed implementation and committed code
+      when: review-agent runs in Phase 4
+      then: |
+        review-agent builds the binary (`go build ./...` from `eigen/`), optionally starts
+        `eigen serve` for serve/navigator changes, exercises relevant curl endpoints and web
+        pages, and produces a compliance report that distinguishes live-verified ACs from
+        statically-verified ones.

--- a/specs/ai-agent/skill-change/changes/011_initial.yaml
+++ b/specs/ai-agent/skill-change/changes/011_initial.yaml
@@ -17,7 +17,9 @@ reason: |
      running the actual binary against live API endpoints and rendered pages. The review
      phase must build the binary and exercise the local environment to verify behavior, not
      just reason about source text.
-status: approved
+status: compiled
+compiled_commits:
+  - 35129aef5cb85834993ee15894d40f0b0e3b0c15
 changes:
   behavior:
     - op: replace

--- a/specs/ai-agent/skill-change/changes/011_initial.yaml
+++ b/specs/ai-agent/skill-change/changes/011_initial.yaml
@@ -17,6 +17,7 @@ reason: |
      running the actual binary against live API endpoints and rendered pages. The review
      phase must build the binary and exercise the local environment to verify behavior, not
      just reason about source text.
+status: approved
 changes:
   behavior:
     - op: replace

--- a/specs/ai-agent/skill-change/changes/012_initial.yaml
+++ b/specs/ai-agent/skill-change/changes/012_initial.yaml
@@ -1,0 +1,34 @@
+format: eigen/v1
+id: chg-012
+sequence: 12
+timestamp: 2026-04-18T14:24:05Z
+author: alexander
+type: updated
+summary: Create PR automatically on approval in Phase 4
+status: compiled
+reason: |
+  The skill completes without creating a PR, leaving the user to run `gh pr create`
+  manually after a successful review. Since the skill already knows the branch name,
+  module path, and a summary of what was implemented, it should create the PR
+  automatically when the user approves in Phase 4.
+changes:
+  behavior:
+    - op: append
+      text: |
+
+        On final approval in Phase 4, the skill creates a GitHub pull request via
+        `gh pr create`. The PR title is derived from the module path and change summary;
+        the body lists the spec path, ACs implemented, and a standard footer. The PR URL
+        is presented to the user as the concluding output.
+  acceptance_criteria:
+    - id: AC-021
+      description: |
+        On "Approve" in Phase 4 PASS case, the skill runs `gh pr create` with a title
+        and body derived from the module path and implemented changes, then presents the
+        PR URL to the user as the final output.
+      given: review-agent returns PASS and the user selects "Approve"
+      when: Phase 4 concludes
+      then: |
+        The skill runs `gh pr create --title "<title>" --body "..."` on the feature branch,
+        captures the PR URL from stdout, and presents it to the user. The PR body includes
+        the spec path, a summary of ACs implemented, and a Claude Code footer.

--- a/specs/ai-agent/skill-change/spec.yaml
+++ b/specs/ai-agent/skill-change/spec.yaml
@@ -4,6 +4,7 @@ domain: ai-agent
 module: skill-change
 owner: alexander
 title: Unified `change` skill — orchestrates spec → plan → compile workflow
+status: compiled
 description: |-
   Refine the feedback loop: when user rejects output at any phase and provides feedback,
   the skill immediately invokes spec-agent to write a new change file incorporating the feedback,

--- a/specs/ai-agent/skill-change/spec.yaml
+++ b/specs/ai-agent/skill-change/spec.yaml
@@ -4,7 +4,6 @@ domain: ai-agent
 module: skill-change
 owner: alexander
 title: Unified `change` skill — orchestrates spec → plan → compile workflow
-status: compiled
 description: |-
   Refine the feedback loop: when user rejects output at any phase and provides feedback,
   the skill immediately invokes spec-agent to write a new change file incorporating the feedback,
@@ -48,6 +47,11 @@ behavior: |
   tools if available). The review-agent reports which environment components it was
   able to start and which acceptance criteria were verified through live execution
   versus static analysis only.
+
+  On final approval in Phase 4, the skill creates a GitHub pull request via
+  `gh pr create`. The PR title is derived from the module path and change summary;
+  the body lists the spec path, ACs implemented, and a standard footer. The PR URL
+  is presented to the user as the concluding output.
 acceptance_criteria:
   - id: AC-001
     description: |
@@ -248,6 +252,17 @@ acceptance_criteria:
       `eigen serve` for serve/navigator changes, exercises relevant curl endpoints and web
       pages, and produces a compliance report that distinguishes live-verified ACs from
       statically-verified ones.
+  - id: AC-021
+    description: |
+      On "Approve" in Phase 4 PASS case, the skill runs `gh pr create` with a title
+      and body derived from the module path and implemented changes, then presents the
+      PR URL to the user as the final output.
+    given: review-agent returns PASS and the user selects "Approve"
+    when: Phase 4 concludes
+    then: |
+      The skill runs `gh pr create --title "<title>" --body "..."` on the feature branch,
+      captures the PR URL from stdout, and presents it to the user. The PR body includes
+      the spec path, a summary of ACs implemented, and a Claude Code footer.
 dependencies: []
 technology:
   AgentTypes: spec-subagent, plan-subagent, compile-subagent
@@ -256,5 +271,5 @@ technology:
     Specs: changes/*.yaml + spec.yaml (eigen-spec format)
     Plans: temporary plan mode UI only (no file written)
     Code: git commits
-last_change: chg-011
-changes_count: 11
+last_change: chg-012
+changes_count: 12

--- a/specs/ai-agent/skill-change/spec.yaml
+++ b/specs/ai-agent/skill-change/spec.yaml
@@ -4,7 +4,6 @@ domain: ai-agent
 module: skill-change
 owner: alexander
 title: Unified `change` skill — orchestrates spec → plan → compile workflow
-status: compiled
 description: |-
   Refine the feedback loop: when user rejects output at any phase and provides feedback,
   the skill immediately invokes spec-agent to write a new change file incorporating the feedback,
@@ -22,25 +21,44 @@ description: |-
   rejection, eigen-change commits the feedback change file after the next spec-agent run
   completes.
 behavior: |
-  The /change skill orchestrates spec -> plan -> compile. At setup it captures both
-  BRANCH (from git branch --show-current) and WORKTREE (the worktree name, derived
-  from the basename of `git rev-parse --show-toplevel`). WORKTREE is threaded into all
-  HTTP API calls to the eigen serve API as a ?worktree= query parameter so modules are
-  correctly disambiguated when the same module path exists in multiple worktrees.
+  The /change skill orchestrates spec -> plan -> compile. At setup it fetches the
+  latest main branch (`git fetch origin main`) and creates a new feature branch from it
+  (`git checkout -b <feature-branch> origin/main`). The skill does NOT continue on the
+  currently checked-out branch unless the user explicitly passes a flag (--branch) or
+  explicitly instructs it to do so. The branch name is derived from the module path or
+  feature description (e.g. `feat/skill-change-branch-from-main`). Setup also captures
+  BRANCH (the new branch name) and WORKTREE (the worktree name, derived from the basename
+  of `git rev-parse --show-toplevel`). WORKTREE is threaded into all HTTP API calls to the
+  eigen serve API as a ?worktree= query parameter so modules are correctly disambiguated
+  when the same module path exists in multiple worktrees.
 
   The approval polling loop checks the HTTP status code of each curl response before
   attempting JSON parsing. If the response is not HTTP 200, the loop logs a diagnostic
   message with the status code and response body. After a configurable number of
   consecutive failures (default 5), the loop exits with an error message instead of
   spinning forever. Python3 stderr is no longer suppressed (2>/dev/null is removed).
+
+  Phase 4 review goes beyond static code analysis. The review-agent is instructed to
+  start up as much of the local environment as possible before evaluating correctness.
+  This includes: building the binary (`go build ./...` from the `eigen/` directory),
+  starting the spec-navigator web server if the change involves the serve/navigator
+  subsystem (`eigen serve &` and waiting for it to be ready), and then verifying
+  behavior by exercising relevant API endpoints (curl) and web pages (fetch or browser
+  tools if available). The review-agent reports which environment components it was
+  able to start and which acceptance criteria were verified through live execution
+  versus static analysis only.
 acceptance_criteria:
   - id: AC-001
     description: |
       `change` skill can be invoked with feature description and optional short-name hint.
-      Skill creates feature branch and calls spec-subagent with the description.
+      At setup the skill fetches origin/main, creates a new feature branch from it, and
+      calls spec-subagent with the description. The skill does NOT continue on the current
+      branch unless the user passes --branch or explicitly instructs it to do so.
     given: A user invokes /change with a feature description
     when: The skill starts execution
-    then: spec-agent is launched with the description; a feature branch is available
+    then: |
+      The skill runs `git fetch origin main` then `git checkout -b <feature-branch> origin/main`,
+      stores the new branch name as BRANCH, and launches spec-agent with the description.
   - id: AC-002
     description: |
       After spec-agent finishes writing change files and running `eigen spec project`,
@@ -203,6 +221,32 @@ acceptance_criteria:
     given: The eigen serve API is returning errors (409, 5xx, or unreachable)
     when: 5 consecutive polling attempts fail
     then: The loop exits with a diagnostic error message instead of spinning indefinitely
+  - id: AC-019
+    description: |
+      At setup, if the user has passed a --branch <name> flag or has explicitly stated they
+      want to continue on the current branch, the skill skips branch creation and uses the
+      existing branch. Otherwise branch creation from origin/main is always performed.
+    given: A user invokes /change without a --branch flag
+    when: The Setup section runs
+    then: |
+      A new branch is created from origin/main; the current branch is not used.
+      If --branch is passed or the user explicitly requests the current branch, branch
+      creation is skipped and BRANCH is set to the existing branch name.
+  - id: AC-020
+    description: |
+      Phase 4 review-agent builds the binary and starts any applicable local services
+      before evaluating correctness. It does not rely solely on static source analysis.
+      For changes involving the spec-navigator or serve subsystem, the agent starts
+      `eigen serve` and waits for it to be ready before exercising API endpoints.
+      The compliance report must state which ACs were verified through live execution
+      vs. static analysis only.
+    given: compile-agent has completed implementation and committed code
+    when: review-agent runs in Phase 4
+    then: |
+      review-agent builds the binary (`go build ./...` from `eigen/`), optionally starts
+      `eigen serve` for serve/navigator changes, exercises relevant curl endpoints and web
+      pages, and produces a compliance report that distinguishes live-verified ACs from
+      statically-verified ones.
 dependencies: []
 technology:
   AgentTypes: spec-subagent, plan-subagent, compile-subagent
@@ -211,5 +255,5 @@ technology:
     Specs: changes/*.yaml + spec.yaml (eigen-spec format)
     Plans: temporary plan mode UI only (no file written)
     Code: git commits
-last_change: chg-010
-changes_count: 10
+last_change: chg-011
+changes_count: 11


### PR DESCRIPTION
## Summary
- Always creates a new branch from \`origin/main\` at setup (with \`--branch\` escape hatch) — spec chg-011 AC-001, AC-019
- Phase 4 review-agent now builds the binary and starts local services before evaluating ACs, with LIVE/STATIC labels in the compliance report — spec chg-011 AC-020
- On Phase 4 approval, skill automatically runs \`gh pr create\` and presents the PR URL — spec chg-012 AC-021

## Spec paths
- \`specs/ai-agent/skill-change/changes/011_initial.yaml\`
- \`specs/ai-agent/skill-change/changes/012_initial.yaml\`

## Files changed
- \`eigen/cmd/skills/eigen-change.md\` + \`.claude/skills/eigen-change/SKILL.md\`
- \`eigen/cmd/skills/eigen-change-review.md\` + \`.claude/skills/eigen-change-review/SKILL.md\`
- \`eigen/cmd/agents/review-agent.md\` + \`.claude/agents/review-agent.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)