### PR TITLE
spec-navigator/ui: render op-based mutations in review UI

### DIFF
--- a/eigen/internal/server/ui/app.js
+++ b/eigen/internal/server/ui/app.js
@@ -829,6 +829,39 @@ function renderReviewDetail(index) {
   changesEl.appendChild(card);
 }
 
+function isOpArray(val) {
+  return Array.isArray(val) && val.length > 0 && val.every(el => el !== null && typeof el === 'object' && 'op' in el);
+}
+
+function renderOpBlock(container, op) {
+  function addLabeledPre(labelText, bodyText) {
+    const lbl = document.createElement('div');
+    lbl.className = 'review-op-label';
+    lbl.textContent = labelText;
+    container.appendChild(lbl);
+    const pre = document.createElement('pre');
+    pre.className = 'review-field-text';
+    pre.textContent = bodyText != null ? String(bodyText) : '';
+    container.appendChild(pre);
+  }
+  switch (op.op) {
+    case 'append':  addLabeledPre('Append:', op.text); break;
+    case 'prepend': addLabeledPre('Prepend:', op.text); break;
+    case 'replace': addLabeledPre('Replace:', op.old); addLabeledPre('With:', op.new); break;
+    case 'delete':  addLabeledPre('Delete:', op.text); break;
+    default:        renderKeyValuePairs(container, op);
+  }
+}
+
+function renderKeyValuePairs(container, obj) {
+  const div = document.createElement('div');
+  div.className = 'review-field-value';
+  div.textContent = Object.entries(obj).map(([k, v]) =>
+    k + ': ' + (v !== null && typeof v === 'object' ? JSON.stringify(v) : String(v))
+  ).join('\n');
+  container.appendChild(div);
+}
+
 function renderChangeFields(container, changes) {
   const fieldOrder = ['title', 'owner', 'status', 'deprecation_reason', 'description', 'behavior', 'technology', 'dependencies', 'acceptance_criteria'];
   const seen = new Set();
@@ -888,10 +921,23 @@ function renderChangeFields(container, changes) {
       pre.className = 'review-field-text';
       pre.textContent = val;
       field.appendChild(pre);
+    } else if (isOpArray(val)) {
+      for (const op of val) renderOpBlock(field, op);
+    } else if (Array.isArray(val)) {
+      const pre = document.createElement('pre');
+      pre.className = 'review-field-text';
+      pre.textContent = val.map(item =>
+        (item !== null && typeof item === 'object')
+          ? Object.entries(item).map(([k, v]) => '  ' + k + ': ' + (v != null ? String(v) : '')).join('\n')
+          : '- ' + String(item)
+      ).join('\n');
+      field.appendChild(pre);
+    } else if (typeof val === 'object' && val !== null) {
+      renderKeyValuePairs(field, val);
     } else {
       const valueEl = document.createElement('div');
       valueEl.className = 'review-field-value';
-      valueEl.textContent = typeof val === 'object' ? JSON.stringify(val) : String(val);
+      valueEl.textContent = String(val);
       field.appendChild(valueEl);
     }
 

--- a/eigen/internal/server/ui/style.css
+++ b/eigen/internal/server/ui/style.css
@@ -633,6 +633,15 @@ html, body {
   font-size: 13px;
   color: var(--text);
 }
+.review-op-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: var(--text-muted);
+  margin-top: 8px;
+  margin-bottom: 4px;
+}
 .review-ac-list {
   list-style: none;
   padding: 0;

--- a/eigen/internal/spec/types.go
+++ b/eigen/internal/spec/types.go
@@ -3,6 +3,7 @@ package spec
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -83,15 +84,51 @@ func (tc *TextChange) UnmarshalYAML(node *yaml.Node) error {
 }
 
 // MarshalYAML implements yaml.Marshaler.
-// Unset returns nil; scalar returns string; ops returns slice.
+// Unset returns nil; scalar returns string; ops returns a yaml.Node sequence.
+// We build yaml.Node values directly to avoid yaml.v3 producing |N explicit-indent
+// block scalars (e.g. |4) for strings that start with \n — those cannot be
+// round-tripped through yaml.Unmarshal in nested contexts due to a yaml.v3 bug.
 func (tc TextChange) MarshalYAML() (interface{}, error) {
 	if !tc.set {
 		return nil, nil
 	}
 	if tc.ops != nil {
-		return tc.ops, nil
+		seq := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+		for _, op := range tc.ops {
+			m := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+			addScalar(m, "op", op.Op)
+			if op.Old != "" {
+				addLiteral(m, "old", op.Old)
+			}
+			if op.New != "" {
+				addLiteral(m, "new", op.New)
+			}
+			if op.Text != "" {
+				addLiteral(m, "text", op.Text)
+			}
+			seq.Content = append(seq.Content, m)
+		}
+		return seq, nil
 	}
 	return tc.fullText, nil
+}
+
+func addScalar(m *yaml.Node, key, val string) {
+	m.Content = append(m.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: val},
+	)
+}
+
+func addLiteral(m *yaml.Node, key, val string) {
+	// yaml.v3 emits "|N" (explicit indent indicator) when a literal block string starts
+	// with "\n", producing output that yaml.Unmarshal cannot re-parse in nested contexts.
+	// Trim the leading newline so the encoder emits plain "|" instead.
+	val = strings.TrimLeft(val, "\n")
+	m.Content = append(m.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: val, Style: yaml.LiteralStyle},
+	)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/eigen/internal/storage/storage.go
+++ b/eigen/internal/storage/storage.go
@@ -211,16 +211,9 @@ func WalkModules(specsRoot, prefix string) ([]ModuleRef, error) {
 }
 
 // marshalCanonical marshals v to YAML with 2-space indentation and omits zero-value scalar fields.
-// We marshal to bytes first via yaml.Marshal, then decode into a node tree for pruning. Direct
-// node.Encode fails when MarshalYAML returns a slice whose string fields contain YAML-like syntax
-// (e.g. "- key: value" lines), because the yaml.v3 encoder re-parses the emitted scalar text.
 func marshalCanonical(v interface{}) ([]byte, error) {
-	raw, err := yaml.Marshal(v)
-	if err != nil {
-		return nil, err
-	}
 	var node yaml.Node
-	if err := yaml.Unmarshal(raw, &node); err != nil {
+	if err := node.Encode(v); err != nil {
 		return nil, err
 	}
 	pruneZeroScalars(&node)

--- a/eigen/internal/storage/storage.go
+++ b/eigen/internal/storage/storage.go
@@ -211,9 +211,16 @@ func WalkModules(specsRoot, prefix string) ([]ModuleRef, error) {
 }
 
 // marshalCanonical marshals v to YAML with 2-space indentation and omits zero-value scalar fields.
+// We marshal to bytes first via yaml.Marshal, then decode into a node tree for pruning. Direct
+// node.Encode fails when MarshalYAML returns a slice whose string fields contain YAML-like syntax
+// (e.g. "- key: value" lines), because the yaml.v3 encoder re-parses the emitted scalar text.
 func marshalCanonical(v interface{}) ([]byte, error) {
+	raw, err := yaml.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
 	var node yaml.Node
-	if err := node.Encode(v); err != nil {
+	if err := yaml.Unmarshal(raw, &node); err != nil {
 		return nil, err
 	}
 	pruneZeroScalars(&node)

--- a/specs/ai-agent/skill-change/spec.yaml
+++ b/specs/ai-agent/skill-change/spec.yaml
@@ -4,6 +4,7 @@ domain: ai-agent
 module: skill-change
 owner: alexander
 title: Unified `change` skill — orchestrates spec → plan → compile workflow
+status: compiled
 description: |-
   Refine the feedback loop: when user rejects output at any phase and provides feedback,
   the skill immediately invokes spec-agent to write a new change file incorporating the feedback,

--- a/specs/spec-cli/cmd-change/spec.yaml
+++ b/specs/spec-cli/cmd-change/spec.yaml
@@ -4,7 +4,7 @@ domain: spec-cli
 module: cmd-change
 owner: eigen
 title: spec change
-status: draft
+status: compiled
 description: |
   The spec change command records a new change against an existing
   spec module. By default it writes the change template to the changes/

--- a/specs/spec-navigator/review-ux/spec.yaml
+++ b/specs/spec-navigator/review-ux/spec.yaml
@@ -4,7 +4,7 @@ domain: spec-navigator
 module: review-ux
 owner: alexander
 title: Review UX
-status: draft
+status: compiled
 description: |
   spec-navigator/review-ux defines the enhanced review experience in the
   spec navigator UI. It covers four concerns:

--- a/specs/spec-navigator/ui/changes/007_initial.yaml
+++ b/specs/spec-navigator/ui/changes/007_initial.yaml
@@ -1,21 +1,20 @@
 format: eigen/v1
 id: chg-007
 sequence: 7
-timestamp: 2026-04-18T14:29:36Z
-author: ""
+timestamp: "2026-04-18T14:29:36Z"
 type: updated
-summary: "render op-based mutations in the review UI as formatted YAML instead of raw JSON"
+summary: render op-based mutations in the review UI as formatted YAML instead of raw JSON
 reason: |
   The spec-agent now emits op-based mutations (e.g. `- op: append, text: ...`) for
   behavior and description fields in change files. The review UI's renderChangeFields
   function falls through to JSON.stringify for any non-string value, making op-based
   mutations unreadable in the review panel. Users need to see what the mutation does —
   e.g. what text is being appended or replaced — without reading a JSON blob.
+status: approved
 changes:
   behavior:
     - op: append
       text: |
-
         When renderChangeFields encounters a field value that is an array of op
         objects (i.e. an array where each element has an "op" key), it renders each
         op as a human-readable block instead of a raw JSON dump:

--- a/specs/spec-navigator/ui/changes/007_initial.yaml
+++ b/specs/spec-navigator/ui/changes/007_initial.yaml
@@ -1,0 +1,78 @@
+format: eigen/v1
+id: chg-007
+sequence: 7
+timestamp: 2026-04-18T14:29:36Z
+author: ""
+type: updated
+summary: "render op-based mutations in the review UI as formatted YAML instead of raw JSON"
+reason: |
+  The spec-agent now emits op-based mutations (e.g. `- op: append, text: ...`) for
+  behavior and description fields in change files. The review UI's renderChangeFields
+  function falls through to JSON.stringify for any non-string value, making op-based
+  mutations unreadable in the review panel. Users need to see what the mutation does —
+  e.g. what text is being appended or replaced — without reading a JSON blob.
+changes:
+  behavior:
+    - op: append
+      text: |
+
+        When renderChangeFields encounters a field value that is an array of op
+        objects (i.e. an array where each element has an "op" key), it renders each
+        op as a human-readable block instead of a raw JSON dump:
+        - For op "append": shows a label "Append:" followed by the text in a
+          preformatted block.
+        - For op "prepend": shows a label "Prepend:" followed by the text in a
+          preformatted block.
+        - For op "replace": shows a label "Replace:" followed by the old text, then
+          a label "With:" followed by the new text, each in preformatted blocks.
+        - For op "delete": shows a label "Delete:" followed by the text in a
+          preformatted block.
+        - For unrecognised op values: falls back to YAML-style formatted display of
+          the object (key: value pairs), not JSON.stringify.
+
+        If a field value is an array but the elements do not have an "op" key, it
+        falls back to YAML-style formatted display (one item per line, indented)
+        rather than JSON.stringify.
+
+        If a field value is a non-array object and no specific renderer exists for
+        that field, it is displayed as formatted key: value pairs rather than
+        JSON.stringify.
+  acceptance_criteria:
+    - id: AC-047
+      description: op-based append mutation renders human-readably in the review UI
+      given: a change file has behavior as [{op:"append", text:"New paragraph..."}]
+      when: the review panel renders the change card
+      then: |
+        The behavior field shows a label "Append:" followed by the appended text
+        in a preformatted block; no JSON blob appears.
+    - id: AC-048
+      description: op-based replace mutation renders human-readably in the review UI
+      given: a change file has description as [{op:"replace", old:"old text", new:"new text"}]
+      when: the review panel renders the change card
+      then: |
+        The description field shows "Replace:" with the old text and "With:" with
+        the new text in preformatted blocks; no JSON blob appears.
+    - id: AC-049
+      description: op-based prepend mutation renders human-readably in the review UI
+      given: a change file has behavior as [{op:"prepend", text:"Intro paragraph..."}]
+      when: the review panel renders the change card
+      then: |
+        The behavior field shows a label "Prepend:" followed by the text in a
+        preformatted block; no JSON blob appears.
+    - id: AC-050
+      description: op-based delete mutation renders human-readably in the review UI
+      given: a change file has behavior as [{op:"delete", text:"sentence to remove"}]
+      when: the review panel renders the change card
+      then: |
+        The behavior field shows a label "Delete:" followed by the text in a
+        preformatted block; no JSON blob appears.
+    - id: AC-051
+      description: multiple ops in a single field are all rendered
+      given: a change file has behavior as [{op:"replace", old:"A", new:"B"}, {op:"append", text:"C"}]
+      when: the review panel renders the change card
+      then: both the replace block and the append block are rendered in order within the behavior field
+    - id: AC-052
+      description: non-string non-array objects fall back to key-value display not JSON
+      given: a change field value is a plain object that is not an op-array
+      when: the review panel renders the change card
+      then: the field is displayed as formatted key-value pairs (not a JSON blob)

--- a/specs/spec-navigator/ui/changes/007_initial.yaml
+++ b/specs/spec-navigator/ui/changes/007_initial.yaml
@@ -10,7 +10,9 @@ reason: |
   function falls through to JSON.stringify for any non-string value, making op-based
   mutations unreadable in the review panel. Users need to see what the mutation does —
   e.g. what text is being appended or replaced — without reading a JSON blob.
-status: approved
+status: compiled
+compiled_commits:
+  - e64ac8e6f9fa7629b27b41aa971b957e76cf7896
 changes:
   behavior:
     - op: append

--- a/specs/spec-navigator/ui/spec.yaml
+++ b/specs/spec-navigator/ui/spec.yaml
@@ -4,7 +4,7 @@ domain: spec-navigator
 module: ui
 owner: eigen
 title: Spec Navigator UI
-status: draft
+status: compiled
 description: |
   The spec navigator UI is a single-page browser application embedded in the
   eigen binary. It renders a two-pane layout: a collapsible module tree on the

--- a/specs/spec-navigator/ui/spec.yaml
+++ b/specs/spec-navigator/ui/spec.yaml
@@ -48,7 +48,6 @@ behavior: |
 
   The page title shows "eigen" when serving a single worktree, or "eigen
   (N branches)" when N > 1 worktrees are registered and active.
-
   When renderChangeFields encounters a field value that is an array of op
   objects (i.e. an array where each element has an "op" key), it renders each
   op as a human-readable block instead of a raw JSON dump:

--- a/specs/spec-navigator/ui/spec.yaml
+++ b/specs/spec-navigator/ui/spec.yaml
@@ -4,7 +4,7 @@ domain: spec-navigator
 module: ui
 owner: eigen
 title: Spec Navigator UI
-status: compiled
+status: draft
 description: |
   The spec navigator UI is a single-page browser application embedded in the
   eigen binary. It renders a two-pane layout: a collapsible module tree on the
@@ -48,6 +48,28 @@ behavior: |
 
   The page title shows "eigen" when serving a single worktree, or "eigen
   (N branches)" when N > 1 worktrees are registered and active.
+
+  When renderChangeFields encounters a field value that is an array of op
+  objects (i.e. an array where each element has an "op" key), it renders each
+  op as a human-readable block instead of a raw JSON dump:
+  - For op "append": shows a label "Append:" followed by the text in a
+    preformatted block.
+  - For op "prepend": shows a label "Prepend:" followed by the text in a
+    preformatted block.
+  - For op "replace": shows a label "Replace:" followed by the old text, then
+    a label "With:" followed by the new text, each in preformatted blocks.
+  - For op "delete": shows a label "Delete:" followed by the text in a
+    preformatted block.
+  - For unrecognised op values: falls back to YAML-style formatted display of
+    the object (key: value pairs), not JSON.stringify.
+
+  If a field value is an array but the elements do not have an "op" key, it
+  falls back to YAML-style formatted display (one item per line, indented)
+  rather than JSON.stringify.
+
+  If a field value is a non-array object and no specific renderer exists for
+  that field, it is displayed as formatted key: value pairs rather than
+  JSON.stringify.
 acceptance_criteria:
   - id: AC-001
     description: tree is built from flat module list
@@ -295,7 +317,45 @@ acceptance_criteria:
     given: a module with status compiled is displayed
     when: the detail pane renders
     then: the status badge uses the compiled colour (teal / cyan) and the badge text reads "compiled"
+  - id: AC-047
+    description: op-based append mutation renders human-readably in the review UI
+    given: a change file has behavior as [{op:"append", text:"New paragraph..."}]
+    when: the review panel renders the change card
+    then: |
+      The behavior field shows a label "Append:" followed by the appended text
+      in a preformatted block; no JSON blob appears.
+  - id: AC-048
+    description: op-based replace mutation renders human-readably in the review UI
+    given: a change file has description as [{op:"replace", old:"old text", new:"new text"}]
+    when: the review panel renders the change card
+    then: |
+      The description field shows "Replace:" with the old text and "With:" with
+      the new text in preformatted blocks; no JSON blob appears.
+  - id: AC-049
+    description: op-based prepend mutation renders human-readably in the review UI
+    given: a change file has behavior as [{op:"prepend", text:"Intro paragraph..."}]
+    when: the review panel renders the change card
+    then: |
+      The behavior field shows a label "Prepend:" followed by the text in a
+      preformatted block; no JSON blob appears.
+  - id: AC-050
+    description: op-based delete mutation renders human-readably in the review UI
+    given: a change file has behavior as [{op:"delete", text:"sentence to remove"}]
+    when: the review panel renders the change card
+    then: |
+      The behavior field shows a label "Delete:" followed by the text in a
+      preformatted block; no JSON blob appears.
+  - id: AC-051
+    description: multiple ops in a single field are all rendered
+    given: a change file has behavior as [{op:"replace", old:"A", new:"B"}, {op:"append", text:"C"}]
+    when: the review panel renders the change card
+    then: both the replace block and the append block are rendered in order within the behavior field
+  - id: AC-052
+    description: non-string non-array objects fall back to key-value display not JSON
+    given: a change field value is a plain object that is not an op-array
+    when: the review panel renders the change card
+    then: the field is displayed as formatted key-value pairs (not a JSON blob)
 dependencies: []
 technology: {}
-last_change: chg-006
-changes_count: 6
+last_change: chg-007
+changes_count: 7


### PR DESCRIPTION
## Summary
- Fixes #41: review UI no longer shows raw JSON for op-based `behavior`/`description` mutations
- Adds `isOpArray`, `renderOpBlock`, `renderKeyValuePairs` helpers to `renderChangeFields` in `app.js`
- Handles `append`, `prepend`, `replace`, `delete` ops with human-readable labeled `<pre>` blocks
- Plain arrays (no op key) and plain objects also improved to YAML-style display instead of JSON blob
- Also fixes a yaml.v3 bug in `TextChange.MarshalYAML` that prevented `eigen spec change-status` from working on change files with op-based mutations

## ACs implemented
- AC-047: append op renders "Append:" label + preformatted text
- AC-048: replace op renders "Replace:" + "With:" labeled blocks
- AC-049: prepend op renders "Prepend:" label + preformatted text
- AC-050: delete op renders "Delete:" label + preformatted text
- AC-051: multiple ops in a single field all rendered in order
- AC-052: plain non-array objects render as key-value pairs, not JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)