### PR TITLE
skill-change: dual-track parallel review in Phase 4

### DIFF
--- a/.claude/skills/eigen-change-review/SKILL.md
+++ b/.claude/skills/eigen-change-review/SKILL.md
@@ -3,7 +3,7 @@ name: eigen-change-review
 description: Run the implementation review phase to verify spec compliance after compile
 ---
 
-Manually invoke the review phase for a compiled module. Launches the review-agent against the spec and presents the compliance report.
+Manually invoke the review phase for a compiled module. Runs two parallel tracks concurrently and merges findings into a single compliance report.
 
 ## Arguments
 `/eigen-change-review <module-path>`
@@ -12,7 +12,9 @@ If module-path is missing, ask for it.
 
 ---
 
-Launch the review-agent:
+Issue TWO parallel tool calls in the same message:
+
+**Track 1 — review-agent subagent:**
 
 ```
 Agent(
@@ -21,19 +23,38 @@ Agent(
     SPEC_PATH: specs/<module-path>/spec.yaml
     MODULE_PATH: <module-path>
 
-    Read the spec and the compiled implementation. Before evaluating correctness:
-    1. Build the binary: run `go build ./...` from the `eigen/` subdirectory of the repo root.
-    2. If the change involves the spec-navigator, serve, or any HTTP API subsystem:
-       - Start `eigen serve &` and wait for it to be ready (poll http://localhost:7171 until HTTP 200).
-       - Exercise relevant API endpoints with curl (e.g. `curl -s http://localhost:7171/api/modules`).
-       - Fetch or check relevant web pages where browser tools are available.
-    3. For all other changes, still build the binary and run `go test ./...`.
+    Read the spec and compiled implementation. Before evaluating:
+    1. Build using the project-appropriate command (e.g. `go build ./...` from `eigen/` for Go projects).
+    2. If the change involves a server or HTTP API:
+       - Start the server and poll until HTTP 200 (30s timeout).
+       - Exercise relevant endpoints with curl and record responses.
+    3. Run the project's test suite and capture output.
 
-    Verify every acceptance criterion. In the compliance report, clearly label each AC as
-    verified through live execution (LIVE) or static analysis only (STATIC).
-
+    Verify every AC. Label each LIVE or STATIC. Include "Track: AGENT" in the report header.
     Return the full compliance report.
 )
 ```
 
-Present the returned report to the user.
+**Track 2 — inline browser verification (main thread, same message as Track 1):**
+
+In the same message as the Track 1 Agent call, use preview MCP tools inline:
+
+1. Read the spec's behavior and AC descriptions for UI/web language ("page", "browser", "frontend", "UI", "button", "form", "route").
+2. If a web UI or local server is applicable:
+   a. Call `preview_start` with the appropriate URL (infer from spec).
+   b. Call `preview_screenshot` — capture initial state.
+   c. Call `preview_snapshot` — read rendered DOM, verify content.
+   d. For ACs involving UI elements/interactions: `preview_click`, then `preview_screenshot`/`preview_snapshot` to verify state changes.
+   e. Record which ACs were visually confirmed and any discrepancies. Label findings "Track: BROWSER".
+3. If no web UI is applicable:
+   - Record: "Track 2 — inline browser verification: no web UI applicable. Browser verification skipped."
+   - This is not a failure.
+
+**After both tracks complete, merge findings:**
+
+- For each AC: combine results. An AC is PASS if either track confirms it (and neither finds a failure for an AC both tracks checked).
+- Label each AC row with the verifying track(s): AGENT, BROWSER, or BOTH.
+- Overall verdict: PASS only if all ACs pass in the combined result.
+- Include a "Verification coverage" section.
+
+Present the merged compliance report to the user.

--- a/.claude/skills/eigen-change/SKILL.md
+++ b/.claude/skills/eigen-change/SKILL.md
@@ -195,7 +195,9 @@ After compile-agent completes, proceed to Phase 4.
 
 ## Phase 4 — Review
 
-Launch the review-agent to verify spec compliance:
+Issue TWO parallel tool calls in the same message:
+
+**Track 1 — review-agent subagent:**
 
 ```
 Agent(
@@ -204,24 +206,43 @@ Agent(
     SPEC_PATH: specs/<module-path>/spec.yaml
     MODULE_PATH: <module-path>
 
-    Read the spec and the compiled implementation. Before evaluating correctness:
-    1. Build the binary: run `go build ./...` from the `eigen/` subdirectory of the repo root.
-    2. If the change involves the spec-navigator, serve, or any HTTP API subsystem:
-       - Start `eigen serve &` and wait for it to be ready (poll http://localhost:7171 until HTTP 200).
-       - Exercise relevant API endpoints with curl (e.g. `curl -s http://localhost:7171/api/modules`).
-       - Fetch or check relevant web pages where browser tools are available.
-    3. For all other changes, still build the binary and run `go test ./...`.
+    Read the spec and compiled implementation. Before evaluating:
+    1. Build using the project-appropriate command (e.g. `go build ./...` from `eigen/` for Go projects).
+    2. If the change involves a server or HTTP API:
+       - Start the server and poll until HTTP 200 (30s timeout).
+       - Exercise relevant endpoints with curl and record responses.
+    3. Run the project's test suite and capture output.
 
-    Verify every acceptance criterion. In the compliance report, clearly label each AC as
-    verified through live execution (LIVE) or static analysis only (STATIC).
-
+    Verify every AC. Label each LIVE or STATIC. Include "Track: AGENT" in the report header.
     Return the full compliance report.
 )
 ```
 
-Present the returned compliance report to the user.
+**Track 2 — inline browser verification (main thread, same message as Track 1):**
 
-Read the summary line from the report:
+In the same message as the Track 1 Agent call, use preview MCP tools inline:
+
+1. Read the spec's behavior and AC descriptions for UI/web language ("page", "browser", "frontend", "UI", "button", "form", "route").
+2. If a web UI or local server is applicable:
+   a. Call `preview_start` with the appropriate URL (infer from spec; e.g. http://localhost:7171 for eigen serve).
+   b. Call `preview_screenshot` — capture initial state.
+   c. Call `preview_snapshot` — read rendered DOM, verify content.
+   d. For ACs involving UI elements/interactions: `preview_click`, then `preview_screenshot`/`preview_snapshot` to verify state changes.
+   e. Record which ACs were visually confirmed and any discrepancies. Label findings "Track: BROWSER".
+3. If no web UI is applicable:
+   - Record: "Track 2 — inline browser verification: no web UI applicable. Browser verification skipped."
+   - This is not a failure.
+
+**After both tracks complete, merge findings:**
+
+- For each AC: combine results. An AC is PASS if either track confirms it (and neither finds a failure for an AC both tracks checked).
+- Label each AC row with the verifying track(s): AGENT, BROWSER, or BOTH.
+- Overall verdict: PASS only if all ACs pass in the combined result.
+- Include a "Verification coverage" section listing which ACs each track covered.
+
+Present the merged compliance report to the user.
+
+Read the summary line from the combined report:
 
 - **PASS** (all ACs pass):
     Use AskUserQuestion to ask:
@@ -242,7 +263,7 @@ Read the summary line from the report:
     - If rejected: prompt for feedback via follow-up AskUserQuestion, run **Spec Feedback Loop** to update spec, restart Phase 2, then re-run Phases 3 and 4.
 
 - **PARTIAL or FAIL** (one or more ACs fail):
-    Tell the user the review found issues and show the Issues section of the report.
+    Tell the user the review found issues and show the Issues section of the combined report.
     Use AskUserQuestion to ask:
     - Question: "Review found failing ACs. Re-compile to fix, or override and approve anyway?"
     - Options: "Re-compile" (pass review Issues as feedback into **Spec Feedback Loop**, restart Phase 2, re-run Phases 3 and 4), "Approve anyway" (create PR and note open issues in summary), "Reject" (provide additional feedback)

--- a/eigen/cmd/skills/eigen-change-review.md
+++ b/eigen/cmd/skills/eigen-change-review.md
@@ -3,7 +3,7 @@ name: eigen-change-review
 description: Run the implementation review phase to verify spec compliance after compile
 ---
 
-Manually invoke the review phase for a compiled module. Launches the review-agent against the spec and presents the compliance report.
+Manually invoke the review phase for a compiled module. Runs two parallel tracks concurrently and merges findings into a single compliance report.
 
 ## Arguments
 `/eigen-change-review <module-path>`
@@ -12,7 +12,9 @@ If module-path is missing, ask for it.
 
 ---
 
-Launch the review-agent:
+Issue TWO parallel tool calls in the same message:
+
+**Track 1 — review-agent subagent:**
 
 ```
 Agent(
@@ -21,19 +23,38 @@ Agent(
     SPEC_PATH: specs/<module-path>/spec.yaml
     MODULE_PATH: <module-path>
 
-    Read the spec and the compiled implementation. Before evaluating correctness:
-    1. Build the binary: run `go build ./...` from the `eigen/` subdirectory of the repo root.
-    2. If the change involves the spec-navigator, serve, or any HTTP API subsystem:
-       - Start `eigen serve &` and wait for it to be ready (poll http://localhost:7171 until HTTP 200).
-       - Exercise relevant API endpoints with curl (e.g. `curl -s http://localhost:7171/api/modules`).
-       - Fetch or check relevant web pages where browser tools are available.
-    3. For all other changes, still build the binary and run `go test ./...`.
+    Read the spec and compiled implementation. Before evaluating:
+    1. Build using the project-appropriate command (e.g. `go build ./...` from `eigen/` for Go projects).
+    2. If the change involves a server or HTTP API:
+       - Start the server and poll until HTTP 200 (30s timeout).
+       - Exercise relevant endpoints with curl and record responses.
+    3. Run the project's test suite and capture output.
 
-    Verify every acceptance criterion. In the compliance report, clearly label each AC as
-    verified through live execution (LIVE) or static analysis only (STATIC).
-
+    Verify every AC. Label each LIVE or STATIC. Include "Track: AGENT" in the report header.
     Return the full compliance report.
 )
 ```
 
-Present the returned report to the user.
+**Track 2 — inline browser verification (main thread, same message as Track 1):**
+
+In the same message as the Track 1 Agent call, use preview MCP tools inline:
+
+1. Read the spec's behavior and AC descriptions for UI/web language ("page", "browser", "frontend", "UI", "button", "form", "route").
+2. If a web UI or local server is applicable:
+   a. Call `preview_start` with the appropriate URL (infer from spec).
+   b. Call `preview_screenshot` — capture initial state.
+   c. Call `preview_snapshot` — read rendered DOM, verify content.
+   d. For ACs involving UI elements/interactions: `preview_click`, then `preview_screenshot`/`preview_snapshot` to verify state changes.
+   e. Record which ACs were visually confirmed and any discrepancies. Label findings "Track: BROWSER".
+3. If no web UI is applicable:
+   - Record: "Track 2 — inline browser verification: no web UI applicable. Browser verification skipped."
+   - This is not a failure.
+
+**After both tracks complete, merge findings:**
+
+- For each AC: combine results. An AC is PASS if either track confirms it (and neither finds a failure for an AC both tracks checked).
+- Label each AC row with the verifying track(s): AGENT, BROWSER, or BOTH.
+- Overall verdict: PASS only if all ACs pass in the combined result.
+- Include a "Verification coverage" section.
+
+Present the merged compliance report to the user.

--- a/eigen/cmd/skills/eigen-change.md
+++ b/eigen/cmd/skills/eigen-change.md
@@ -195,7 +195,9 @@ After compile-agent completes, proceed to Phase 4.
 
 ## Phase 4 — Review
 
-Launch the review-agent to verify spec compliance:
+Issue TWO parallel tool calls in the same message:
+
+**Track 1 — review-agent subagent:**
 
 ```
 Agent(
@@ -204,24 +206,43 @@ Agent(
     SPEC_PATH: specs/<module-path>/spec.yaml
     MODULE_PATH: <module-path>
 
-    Read the spec and the compiled implementation. Before evaluating correctness:
-    1. Build the binary: run `go build ./...` from the `eigen/` subdirectory of the repo root.
-    2. If the change involves the spec-navigator, serve, or any HTTP API subsystem:
-       - Start `eigen serve &` and wait for it to be ready (poll http://localhost:7171 until HTTP 200).
-       - Exercise relevant API endpoints with curl (e.g. `curl -s http://localhost:7171/api/modules`).
-       - Fetch or check relevant web pages where browser tools are available.
-    3. For all other changes, still build the binary and run `go test ./...`.
+    Read the spec and compiled implementation. Before evaluating:
+    1. Build using the project-appropriate command (e.g. `go build ./...` from `eigen/` for Go projects).
+    2. If the change involves a server or HTTP API:
+       - Start the server and poll until HTTP 200 (30s timeout).
+       - Exercise relevant endpoints with curl and record responses.
+    3. Run the project's test suite and capture output.
 
-    Verify every acceptance criterion. In the compliance report, clearly label each AC as
-    verified through live execution (LIVE) or static analysis only (STATIC).
-
+    Verify every AC. Label each LIVE or STATIC. Include "Track: AGENT" in the report header.
     Return the full compliance report.
 )
 ```
 
-Present the returned compliance report to the user.
+**Track 2 — inline browser verification (main thread, same message as Track 1):**
 
-Read the summary line from the report:
+In the same message as the Track 1 Agent call, use preview MCP tools inline:
+
+1. Read the spec's behavior and AC descriptions for UI/web language ("page", "browser", "frontend", "UI", "button", "form", "route").
+2. If a web UI or local server is applicable:
+   a. Call `preview_start` with the appropriate URL (infer from spec; e.g. http://localhost:7171 for eigen serve).
+   b. Call `preview_screenshot` — capture initial state.
+   c. Call `preview_snapshot` — read rendered DOM, verify content.
+   d. For ACs involving UI elements/interactions: `preview_click`, then `preview_screenshot`/`preview_snapshot` to verify state changes.
+   e. Record which ACs were visually confirmed and any discrepancies. Label findings "Track: BROWSER".
+3. If no web UI is applicable:
+   - Record: "Track 2 — inline browser verification: no web UI applicable. Browser verification skipped."
+   - This is not a failure.
+
+**After both tracks complete, merge findings:**
+
+- For each AC: combine results. An AC is PASS if either track confirms it (and neither finds a failure for an AC both tracks checked).
+- Label each AC row with the verifying track(s): AGENT, BROWSER, or BOTH.
+- Overall verdict: PASS only if all ACs pass in the combined result.
+- Include a "Verification coverage" section listing which ACs each track covered.
+
+Present the merged compliance report to the user.
+
+Read the summary line from the combined report:
 
 - **PASS** (all ACs pass):
     Use AskUserQuestion to ask:
@@ -242,7 +263,7 @@ Read the summary line from the report:
     - If rejected: prompt for feedback via follow-up AskUserQuestion, run **Spec Feedback Loop** to update spec, restart Phase 2, then re-run Phases 3 and 4.
 
 - **PARTIAL or FAIL** (one or more ACs fail):
-    Tell the user the review found issues and show the Issues section of the report.
+    Tell the user the review found issues and show the Issues section of the combined report.
     Use AskUserQuestion to ask:
     - Question: "Review found failing ACs. Re-compile to fix, or override and approve anyway?"
     - Options: "Re-compile" (pass review Issues as feedback into **Spec Feedback Loop**, restart Phase 2, re-run Phases 3 and 4), "Approve anyway" (create PR and note open issues in summary), "Reject" (provide additional feedback)

--- a/specs/ai-agent/skill-change/changes/013_initial.yaml
+++ b/specs/ai-agent/skill-change/changes/013_initial.yaml
@@ -1,0 +1,75 @@
+format: eigen/v1
+id: chg-013
+sequence: 13
+timestamp: 2026-04-18T15:22:30Z
+author: alexander
+type: updated
+summary: Phase 4 runs dual-track parallel review — review-agent subagent plus inline browser verification via preview MCP tools
+reason: |
+  Static analysis and build checks are not sufficient to verify runtime behavior for changes
+  that affect a running application's UI or API. Phase 4 should concurrently run the
+  review-agent subagent (Go build, curl/API checks, static analysis) AND perform inline
+  browser verification in the main conversation thread using preview MCP tools
+  (preview_start, preview_screenshot, preview_snapshot, preview_click, etc.). Both tracks
+  run as parallel tool calls in the same message. The combined findings are merged into a
+  single compliance report. This pattern applies to any project, not just eigen, and the
+  companion eigen-change-review skill follows the same approach so users get browser testing
+  when invoking it manually.
+changes:
+  behavior:
+    - op: delete
+      text: "Phase 4 review goes beyond static code analysis. The review-agent is instructed to\nstart up as much of the local environment as possible before evaluating correctness.\nThis includes: building the binary (`go build ./...` from the `eigen/` directory),\nstarting the spec-navigator web server if the change involves the serve/navigator\nsubsystem (`eigen serve &` and waiting for it to be ready), and then verifying\nbehavior by exercising relevant API endpoints (curl) and web pages (fetch or browser\ntools if available). The review-agent reports which environment components it was\nable to start and which acceptance criteria were verified through live execution\nversus static analysis only.\n\n"
+    - op: append
+      text: |
+
+        Phase 4 review runs TWO parallel tracks concurrently (issued as parallel tool calls
+        in the same message):
+
+        Track 1 — review-agent subagent: static analysis, build checks (e.g. `go build ./...`
+        or the project-appropriate build command), and API/endpoint verification via curl or
+        equivalent CLI tools. The review-agent starts the local environment as needed (e.g.
+        starting a local server and waiting for it to be ready) before exercising endpoints.
+        It reports which ACs were verified through live execution vs. static analysis.
+
+        Track 2 — inline browser verification: the main conversation thread uses preview MCP
+        tools (preview_start, preview_screenshot, preview_snapshot, preview_click, etc.) to
+        open the running application in a browser and visually verify UI and runtime behavior.
+        This track runs inline (not in a subagent) so preview MCP tools are available.
+        If the change does not involve a web UI, Track 2 still runs but notes that no browser
+        verification was applicable and reports its finding accordingly.
+
+        Both tracks run in the same message as parallel tool calls. After both complete, their
+        findings are merged into a single compliance report that distinguishes which ACs were
+        verified by each track. The PASS/FAIL verdict is based on the combined results.
+
+        This dual-track pattern is general and applies to any project, not only eigen.
+  acceptance_criteria:
+    - id: AC-020
+      description: |
+        Phase 4 runs TWO parallel tracks simultaneously: (1) the review-agent subagent
+        performs static analysis, build verification, and API/curl checks; (2) the main
+        conversation thread performs inline browser verification using preview MCP tools
+        (preview_start, preview_screenshot, preview_snapshot, preview_click, etc.).
+        Both tracks are issued as parallel tool calls in the same message. After both
+        complete, their findings are merged into a single compliance report. This pattern
+        is general — it applies to any project — and is not gated on whether the change
+        involves a specific subsystem.
+      given: compile-agent has completed implementation and committed code
+      when: eigen-change enters Phase 4
+      then: |
+        Both tracks start in parallel in the same message. The review-agent subagent runs
+        build + static + API checks. The main thread runs preview MCP tools to open the
+        application in a browser and verify runtime/UI behavior. The merged compliance
+        report states which ACs were verified by each track and gives a combined PASS/FAIL.
+    - id: AC-022
+      description: |
+        The eigen-change-review companion skill (for manual invocation of Phase 4) follows
+        the same dual-track pattern as the main eigen-change skill: it runs the review-agent
+        subagent AND inline browser verification via preview MCP tools in parallel, merging
+        results into a single compliance report.
+      given: A user manually invokes the eigen-change-review companion skill
+      when: The review phase executes
+      then: |
+        review-agent subagent and inline preview MCP browser verification run as parallel
+        tool calls. Findings are merged. The same PASS/FAIL logic applies as in Phase 4
+        of the main eigen-change skill.

--- a/specs/ai-agent/skill-change/changes/013_initial.yaml
+++ b/specs/ai-agent/skill-change/changes/013_initial.yaml
@@ -1,7 +1,7 @@
 format: eigen/v1
 id: chg-013
 sequence: 13
-timestamp: 2026-04-18T15:22:30Z
+timestamp: "2026-04-18T15:22:30Z"
 author: alexander
 type: updated
 summary: Phase 4 runs dual-track parallel review — review-agent subagent plus inline browser verification via preview MCP tools
@@ -15,13 +15,23 @@ reason: |
   single compliance report. This pattern applies to any project, not just eigen, and the
   companion eigen-change-review skill follows the same approach so users get browser testing
   when invoking it manually.
+status: approved
 changes:
   behavior:
     - op: delete
-      text: "Phase 4 review goes beyond static code analysis. The review-agent is instructed to\nstart up as much of the local environment as possible before evaluating correctness.\nThis includes: building the binary (`go build ./...` from the `eigen/` directory),\nstarting the spec-navigator web server if the change involves the serve/navigator\nsubsystem (`eigen serve &` and waiting for it to be ready), and then verifying\nbehavior by exercising relevant API endpoints (curl) and web pages (fetch or browser\ntools if available). The review-agent reports which environment components it was\nable to start and which acceptance criteria were verified through live execution\nversus static analysis only.\n\n"
+      text: |+
+        Phase 4 review goes beyond static code analysis. The review-agent is instructed to
+        start up as much of the local environment as possible before evaluating correctness.
+        This includes: building the binary (`go build ./...` from the `eigen/` directory),
+        starting the spec-navigator web server if the change involves the serve/navigator
+        subsystem (`eigen serve &` and waiting for it to be ready), and then verifying
+        behavior by exercising relevant API endpoints (curl) and web pages (fetch or browser
+        tools if available). The review-agent reports which environment components it was
+        able to start and which acceptance criteria were verified through live execution
+        versus static analysis only.
+
     - op: append
       text: |
-
         Phase 4 review runs TWO parallel tracks concurrently (issued as parallel tool calls
         in the same message):
 

--- a/specs/ai-agent/skill-change/changes/013_initial.yaml
+++ b/specs/ai-agent/skill-change/changes/013_initial.yaml
@@ -15,7 +15,9 @@ reason: |
   single compliance report. This pattern applies to any project, not just eigen, and the
   companion eigen-change-review skill follows the same approach so users get browser testing
   when invoking it manually.
-status: approved
+status: compiled
+compiled_commits:
+  - c6ea8b73a0fe48009edb543cc4a90525e5f1d07e
 changes:
   behavior:
     - op: delete

--- a/specs/ai-agent/skill-change/spec.yaml
+++ b/specs/ai-agent/skill-change/spec.yaml
@@ -4,6 +4,7 @@ domain: ai-agent
 module: skill-change
 owner: alexander
 title: Unified `change` skill — orchestrates spec → plan → compile workflow
+status: compiled
 description: |-
   Refine the feedback loop: when user rejects output at any phase and provides feedback,
   the skill immediately invokes spec-agent to write a new change file incorporating the feedback,

--- a/specs/ai-agent/skill-change/spec.yaml
+++ b/specs/ai-agent/skill-change/spec.yaml
@@ -4,7 +4,6 @@ domain: ai-agent
 module: skill-change
 owner: alexander
 title: Unified `change` skill — orchestrates spec → plan → compile workflow
-status: compiled
 description: |-
   Refine the feedback loop: when user rejects output at any phase and provides feedback,
   the skill immediately invokes spec-agent to write a new change file incorporating the feedback,
@@ -39,20 +38,32 @@ behavior: |
   consecutive failures (default 5), the loop exits with an error message instead of
   spinning forever. Python3 stderr is no longer suppressed (2>/dev/null is removed).
 
-  Phase 4 review goes beyond static code analysis. The review-agent is instructed to
-  start up as much of the local environment as possible before evaluating correctness.
-  This includes: building the binary (`go build ./...` from the `eigen/` directory),
-  starting the spec-navigator web server if the change involves the serve/navigator
-  subsystem (`eigen serve &` and waiting for it to be ready), and then verifying
-  behavior by exercising relevant API endpoints (curl) and web pages (fetch or browser
-  tools if available). The review-agent reports which environment components it was
-  able to start and which acceptance criteria were verified through live execution
-  versus static analysis only.
-
   On final approval in Phase 4, the skill creates a GitHub pull request via
   `gh pr create`. The PR title is derived from the module path and change summary;
   the body lists the spec path, ACs implemented, and a standard footer. The PR URL
   is presented to the user as the concluding output.
+
+  Phase 4 review runs TWO parallel tracks concurrently (issued as parallel tool calls
+  in the same message):
+
+  Track 1 — review-agent subagent: static analysis, build checks (e.g. `go build ./...`
+  or the project-appropriate build command), and API/endpoint verification via curl or
+  equivalent CLI tools. The review-agent starts the local environment as needed (e.g.
+  starting a local server and waiting for it to be ready) before exercising endpoints.
+  It reports which ACs were verified through live execution vs. static analysis.
+
+  Track 2 — inline browser verification: the main conversation thread uses preview MCP
+  tools (preview_start, preview_screenshot, preview_snapshot, preview_click, etc.) to
+  open the running application in a browser and visually verify UI and runtime behavior.
+  This track runs inline (not in a subagent) so preview MCP tools are available.
+  If the change does not involve a web UI, Track 2 still runs but notes that no browser
+  verification was applicable and reports its finding accordingly.
+
+  Both tracks run in the same message as parallel tool calls. After both complete, their
+  findings are merged into a single compliance report that distinguishes which ACs were
+  verified by each track. The PASS/FAIL verdict is based on the combined results.
+
+  This dual-track pattern is general and applies to any project, not only eigen.
 acceptance_criteria:
   - id: AC-001
     description: |
@@ -240,19 +251,21 @@ acceptance_criteria:
       creation is skipped and BRANCH is set to the existing branch name.
   - id: AC-020
     description: |
-      Phase 4 review-agent builds the binary and starts any applicable local services
-      before evaluating correctness. It does not rely solely on static source analysis.
-      For changes involving the spec-navigator or serve subsystem, the agent starts
-      `eigen serve` and waits for it to be ready before exercising API endpoints.
-      The compliance report must state which ACs were verified through live execution
-      vs. static analysis only.
+      Phase 4 runs TWO parallel tracks simultaneously: (1) the review-agent subagent
+      performs static analysis, build verification, and API/curl checks; (2) the main
+      conversation thread performs inline browser verification using preview MCP tools
+      (preview_start, preview_screenshot, preview_snapshot, preview_click, etc.).
+      Both tracks are issued as parallel tool calls in the same message. After both
+      complete, their findings are merged into a single compliance report. This pattern
+      is general — it applies to any project — and is not gated on whether the change
+      involves a specific subsystem.
     given: compile-agent has completed implementation and committed code
-    when: review-agent runs in Phase 4
+    when: eigen-change enters Phase 4
     then: |
-      review-agent builds the binary (`go build ./...` from `eigen/`), optionally starts
-      `eigen serve` for serve/navigator changes, exercises relevant curl endpoints and web
-      pages, and produces a compliance report that distinguishes live-verified ACs from
-      statically-verified ones.
+      Both tracks start in parallel in the same message. The review-agent subagent runs
+      build + static + API checks. The main thread runs preview MCP tools to open the
+      application in a browser and verify runtime/UI behavior. The merged compliance
+      report states which ACs were verified by each track and gives a combined PASS/FAIL.
   - id: AC-021
     description: |
       On "Approve" in Phase 4 PASS case, the skill runs `gh pr create` with a title
@@ -264,6 +277,18 @@ acceptance_criteria:
       The skill runs `gh pr create --title "<title>" --body "..."` on the feature branch,
       captures the PR URL from stdout, and presents it to the user. The PR body includes
       the spec path, a summary of ACs implemented, and a Claude Code footer.
+  - id: AC-022
+    description: |
+      The eigen-change-review companion skill (for manual invocation of Phase 4) follows
+      the same dual-track pattern as the main eigen-change skill: it runs the review-agent
+      subagent AND inline browser verification via preview MCP tools in parallel, merging
+      results into a single compliance report.
+    given: A user manually invokes the eigen-change-review companion skill
+    when: The review phase executes
+    then: |
+      review-agent subagent and inline preview MCP browser verification run as parallel
+      tool calls. Findings are merged. The same PASS/FAIL logic applies as in Phase 4
+      of the main eigen-change skill.
 dependencies: []
 technology:
   AgentTypes: spec-subagent, plan-subagent, compile-subagent
@@ -272,5 +297,5 @@ technology:
     Specs: changes/*.yaml + spec.yaml (eigen-spec format)
     Plans: temporary plan mode UI only (no file written)
     Code: git commits
-last_change: chg-012
-changes_count: 12
+last_change: chg-013
+changes_count: 13

--- a/specs/ai-agent/skill-change/spec.yaml
+++ b/specs/ai-agent/skill-change/spec.yaml
@@ -42,7 +42,6 @@ behavior: |
   `gh pr create`. The PR title is derived from the module path and change summary;
   the body lists the spec path, ACs implemented, and a standard footer. The PR URL
   is presented to the user as the concluding output.
-
   Phase 4 review runs TWO parallel tracks concurrently (issued as parallel tool calls
   in the same message):
 


### PR DESCRIPTION
## Summary
- Spec: specs/ai-agent/skill-change/spec.yaml
- Fixes limitation where Phase 4 review was subagent-only and couldn't use browser/preview MCP tools
- Phase 4 now issues two parallel tool calls: Track 1 (review-agent subagent for build/tests/API) + Track 2 (inline preview MCP browser verification in main thread)
- Findings merged into single compliance report with per-AC track labels (AGENT, BROWSER, BOTH)
- Graceful fallback when no web UI is applicable
- Pattern is general — works for any project, not eigen-specific
- eigen-change-review companion skill updated to the same dual-track pattern
- ACs implemented: AC-020, AC-022

🤖 Generated with [Claude Code](https://claude.com/claude-code)