### PR TITLE
fix: clear stale review_comment before re-poll; slugify WriteChange filename from Summary

### DIFF
--- a/.claude/skills/eigen-change/SKILL.md
+++ b/.claude/skills/eigen-change/SKILL.md
@@ -123,6 +123,13 @@ After spec-agent returns, commit all pending spec files:
   git add specs/<module-path>/
   git commit -m "spec(<module>): incorporate feedback on <aspect>"
 (Use the aspect/summary from spec-agent's report.)
+
+Clear stale review_comment values before re-entering the poll. For each change file
+that previously had a non-empty review_comment (the filenames extracted during the
+rejection step), run:
+  eigen spec change-comment <module-path> <filename> ""
+This prevents old rejection comments from triggering a false positive on the next poll.
+
 Then re-enter the review cycle (poll module changes from step 2).
 
 ---

--- a/eigen/cmd/skills/eigen-change.md
+++ b/eigen/cmd/skills/eigen-change.md
@@ -123,6 +123,13 @@ After spec-agent returns, commit all pending spec files:
   git add specs/<module-path>/
   git commit -m "spec(<module>): incorporate feedback on <aspect>"
 (Use the aspect/summary from spec-agent's report.)
+
+Clear stale review_comment values before re-entering the poll. For each change file
+that previously had a non-empty review_comment (the filenames extracted during the
+rejection step), run:
+  eigen spec change-comment <module-path> <filename> ""
+This prevents old rejection comments from triggering a false positive on the next poll.
+
 Then re-enter the review cycle (poll module changes from step 2).
 
 ---

--- a/eigen/internal/storage/storage.go
+++ b/eigen/internal/storage/storage.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -77,9 +78,13 @@ func WriteSpec(specsRoot, path string, s spec.SpecModule) error {
 	return nil
 }
 
-// WriteChange writes a Change to the changes/ directory with the given sequence number and slug.
-func WriteChange(specsRoot, path string, ch spec.Change, slug string) error {
+// WriteChange writes a Change to the changes/ directory, deriving the filename slug from ch.Summary.
+func WriteChange(specsRoot, path string, ch spec.Change) error {
 	dir := ChangesPath(specsRoot, path)
+	slug := slugify(ch.Summary)
+	if slug == "" {
+		slug = "initial"
+	}
 	filename := fmt.Sprintf("%03d_%s.yaml", ch.Sequence, slug)
 	data, err := marshalCanonical(ch)
 	if err != nil {
@@ -224,6 +229,18 @@ func marshalCanonical(v interface{}) ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+var storageNonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
+
+func slugify(s string) string {
+	s = strings.ToLower(s)
+	s = storageNonAlnum.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	if len(s) > 40 {
+		s = s[:40]
+	}
+	return s
 }
 
 // pruneZeroScalars removes mapping entries whose value is an empty string or "0".

--- a/eigen/internal/storage/storage_test.go
+++ b/eigen/internal/storage/storage_test.go
@@ -227,8 +227,8 @@ func TestWriteChange(t *testing.T) {
 		root := t.TempDir()
 		setupModule(t, root, "mymod")
 
-		ch := spec.Change{ID: "chg-007", Sequence: 7, Summary: "feature"}
-		if err := WriteChange(root, "mymod", ch, "add-feature"); err != nil {
+		ch := spec.Change{ID: "chg-007", Sequence: 7, Summary: "add-feature"}
+		if err := WriteChange(root, "mymod", ch); err != nil {
 			t.Fatalf("WriteChange error: %v", err)
 		}
 
@@ -262,7 +262,7 @@ func TestWriteChange(t *testing.T) {
 			},
 		}
 
-		if err := WriteChange(root, "mymod", original, "initial"); err != nil {
+		if err := WriteChange(root, "mymod", original); err != nil {
 			t.Fatalf("WriteChange error: %v", err)
 		}
 
@@ -285,6 +285,64 @@ func TestWriteChange(t *testing.T) {
 		}
 		if got.Changes.Title != original.Changes.Title {
 			t.Errorf("Changes.Title = %q, want %q", got.Changes.Title, original.Changes.Title)
+		}
+	})
+
+	// AC-030: slugified summary used as filename
+	t.Run("slugified_summary_as_filename_AC030", func(t *testing.T) {
+		root := t.TempDir()
+		setupModule(t, root, "mymod")
+
+		ch := spec.Change{Sequence: 4, Summary: "Add validation for empty modules"}
+		if err := WriteChange(root, "mymod", ch); err != nil {
+			t.Fatalf("WriteChange error: %v", err)
+		}
+
+		path := filepath.Join(ChangesPath(root, "mymod"), "004_add-validation-for-empty-modules.yaml")
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected file %q not found: %v", path, err)
+		}
+	})
+
+	// AC-031: empty summary falls back to "initial"
+	t.Run("empty_summary_falls_back_to_initial_AC031", func(t *testing.T) {
+		root := t.TempDir()
+		setupModule(t, root, "mymod")
+
+		ch := spec.Change{Sequence: 5, Summary: ""}
+		if err := WriteChange(root, "mymod", ch); err != nil {
+			t.Fatalf("WriteChange error: %v", err)
+		}
+
+		path := filepath.Join(ChangesPath(root, "mymod"), "005_initial.yaml")
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected file %q not found: %v", path, err)
+		}
+	})
+
+	// AC-032: slug truncated to 40 characters
+	t.Run("long_summary_slug_truncated_to_40_chars_AC032", func(t *testing.T) {
+		root := t.TempDir()
+		setupModule(t, root, "mymod")
+
+		ch := spec.Change{Sequence: 6, Summary: "This is a very long summary that should be truncated to forty characters max in the slug"}
+		if err := WriteChange(root, "mymod", ch); err != nil {
+			t.Fatalf("WriteChange error: %v", err)
+		}
+
+		entries, err := os.ReadDir(ChangesPath(root, "mymod"))
+		if err != nil {
+			t.Fatalf("reading changes dir: %v", err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 file, got %d", len(entries))
+		}
+		filename := entries[0].Name()
+		// Strip "006_" prefix and ".yaml" suffix to get slug portion
+		slug := strings.TrimPrefix(filename, "006_")
+		slug = strings.TrimSuffix(slug, ".yaml")
+		if len(slug) > 40 {
+			t.Errorf("slug %q has length %d, want <= 40", slug, len(slug))
 		}
 	})
 }
@@ -624,7 +682,7 @@ func TestWriteChangeIndentation(t *testing.T) {
 		},
 	}
 
-	if err := WriteChange(root, "mymod", ch, "initial"); err != nil {
+	if err := WriteChange(root, "mymod", ch); err != nil {
 		t.Fatalf("WriteChange error: %v", err)
 	}
 
@@ -650,7 +708,7 @@ func TestWriteChangeOmitsZeroValues(t *testing.T) {
 		Status:  "draft",
 	}
 
-	if err := WriteChange(root, "mymod", ch, "something"); err != nil {
+	if err := WriteChange(root, "mymod", ch); err != nil {
 		t.Fatalf("WriteChange error: %v", err)
 	}
 

--- a/specs/ai-agent/skill-change/changes/014_initial.yaml
+++ b/specs/ai-agent/skill-change/changes/014_initial.yaml
@@ -22,6 +22,7 @@ reason: |
 status: compiled
 compiled_commits:
   - fc7e0ec52133533150c5e92abc1422c1f945a8cf
+  - a5c1bfabeb37d3a6fcac60949891b1c111ba2acf
 changes:
   behavior:
     - op: append

--- a/specs/ai-agent/skill-change/changes/014_initial.yaml
+++ b/specs/ai-agent/skill-change/changes/014_initial.yaml
@@ -1,0 +1,46 @@
+format: eigen/v1
+id: chg-014
+sequence: 14
+timestamp: "2026-04-18T16:29:57Z"
+author: alexander
+type: updated
+summary: Clear stale review_comment on change files before re-entering the approval poll
+reason: |
+  Bug #15: after a rejection, the skill records feedback via `eigen spec change-comment`
+  on the change files. When the spec-agent finishes incorporating feedback and the skill
+  re-enters the approval poll, those review_comment values are still present on the
+  change files. The polling loop checks whether any change file has a review_comment set
+  to detect rejection — so the stale comments from the previous rejection cycle
+  immediately trigger a false positive "REJECTED" result on the very next poll, before the
+  user has had any chance to review the updated spec.
+
+  Fix: before re-entering the approval poll (step 2), clear the review_comment on every
+  change file that was just processed by running
+  `eigen spec change-comment <module> <file> ""` for each one. This ensures only a
+  genuine new rejection (where the user explicitly writes a new comment) is detected as a
+  rejection.
+changes:
+  behavior:
+    - op: append
+      text: |
+
+        After a spec rejection is processed and spec-agent writes the feedback change
+        file, the skill clears the stale review_comment on all change files before
+        re-entering the approval poll: for each change file run
+        `eigen spec change-comment <module-path> <filename> ""`.
+        This prevents old rejection comments from triggering a false positive on the
+        next poll.
+  acceptance_criteria:
+    - id: AC-023
+      description: |
+        After a rejection → Spec Feedback Loop → spec-agent run cycle completes,
+        the skill clears the review_comment field on all change files that were
+        previously commented before re-entering the approval poll. This prevents
+        stale comments from triggering a false rejection on the next poll.
+      given: A spec rejection has been processed and spec-agent has written an updated change file
+      when: eigen-change is about to re-enter the approval poll (step 2)
+      then: |
+        It runs `eigen spec change-comment <module-path> <filename> ""` for each change
+        file that previously had a review_comment, clearing the stale value before the
+        next poll begins. The next poll only detects a rejection if the user writes a
+        new comment in the review UI.

--- a/specs/ai-agent/skill-change/changes/014_initial.yaml
+++ b/specs/ai-agent/skill-change/changes/014_initial.yaml
@@ -19,11 +19,11 @@ reason: |
   `eigen spec change-comment <module> <file> ""` for each one. This ensures only a
   genuine new rejection (where the user explicitly writes a new comment) is detected as a
   rejection.
+status: approved
 changes:
   behavior:
     - op: append
       text: |
-
         After a spec rejection is processed and spec-agent writes the feedback change
         file, the skill clears the stale review_comment on all change files before
         re-entering the approval poll: for each change file run

--- a/specs/ai-agent/skill-change/changes/014_initial.yaml
+++ b/specs/ai-agent/skill-change/changes/014_initial.yaml
@@ -19,7 +19,9 @@ reason: |
   `eigen spec change-comment <module> <file> ""` for each one. This ensures only a
   genuine new rejection (where the user explicitly writes a new comment) is detected as a
   rejection.
-status: approved
+status: compiled
+compiled_commits:
+  - fc7e0ec52133533150c5e92abc1422c1f945a8cf
 changes:
   behavior:
     - op: append

--- a/specs/ai-agent/skill-change/spec.yaml
+++ b/specs/ai-agent/skill-change/spec.yaml
@@ -4,6 +4,7 @@ domain: ai-agent
 module: skill-change
 owner: alexander
 title: Unified `change` skill — orchestrates spec → plan → compile workflow
+status: compiled
 description: |-
   Refine the feedback loop: when user rejects output at any phase and provides feedback,
   the skill immediately invokes spec-agent to write a new change file incorporating the feedback,

--- a/specs/ai-agent/skill-change/spec.yaml
+++ b/specs/ai-agent/skill-change/spec.yaml
@@ -4,7 +4,6 @@ domain: ai-agent
 module: skill-change
 owner: alexander
 title: Unified `change` skill — orchestrates spec → plan → compile workflow
-status: compiled
 description: |-
   Refine the feedback loop: when user rejects output at any phase and provides feedback,
   the skill immediately invokes spec-agent to write a new change file incorporating the feedback,
@@ -64,6 +63,13 @@ behavior: |
   verified by each track. The PASS/FAIL verdict is based on the combined results.
 
   This dual-track pattern is general and applies to any project, not only eigen.
+
+  After a spec rejection is processed and spec-agent writes the feedback change
+  file, the skill clears the stale review_comment on all change files before
+  re-entering the approval poll: for each change file run
+  `eigen spec change-comment <module-path> <filename> ""`.
+  This prevents old rejection comments from triggering a false positive on the
+  next poll.
 acceptance_criteria:
   - id: AC-001
     description: |
@@ -289,6 +295,19 @@ acceptance_criteria:
       review-agent subagent and inline preview MCP browser verification run as parallel
       tool calls. Findings are merged. The same PASS/FAIL logic applies as in Phase 4
       of the main eigen-change skill.
+  - id: AC-023
+    description: |
+      After a rejection → Spec Feedback Loop → spec-agent run cycle completes,
+      the skill clears the review_comment field on all change files that were
+      previously commented before re-entering the approval poll. This prevents
+      stale comments from triggering a false rejection on the next poll.
+    given: A spec rejection has been processed and spec-agent has written an updated change file
+    when: eigen-change is about to re-enter the approval poll (step 2)
+    then: |
+      It runs `eigen spec change-comment <module-path> <filename> ""` for each change
+      file that previously had a review_comment, clearing the stale value before the
+      next poll begins. The next poll only detects a rejection if the user writes a
+      new comment in the review UI.
 dependencies: []
 technology:
   AgentTypes: spec-subagent, plan-subagent, compile-subagent
@@ -297,5 +316,5 @@ technology:
     Specs: changes/*.yaml + spec.yaml (eigen-spec format)
     Plans: temporary plan mode UI only (no file written)
     Code: git commits
-last_change: chg-013
-changes_count: 13
+last_change: chg-014
+changes_count: 14

--- a/specs/ai-agent/skill-change/spec.yaml
+++ b/specs/ai-agent/skill-change/spec.yaml
@@ -63,7 +63,6 @@ behavior: |
   verified by each track. The PASS/FAIL verdict is based on the combined results.
 
   This dual-track pattern is general and applies to any project, not only eigen.
-
   After a spec rejection is processed and spec-agent writes the feedback change
   file, the skill clears the stale review_comment on all change files before
   re-entering the approval poll: for each change file run

--- a/specs/spec-cli/storage/changes/003_slugify-summary-in-filename.yaml
+++ b/specs/spec-cli/storage/changes/003_slugify-summary-in-filename.yaml
@@ -12,7 +12,9 @@ reason: |
   WriteChange (and its callers) use the slugified Summary as the filename slug
   whenever Summary is non-empty, reserving "_initial" only for the case where
   Summary is truly empty.
-status: approved
+status: compiled
+compiled_commits:
+  - bd11c44249b853deb8aca5be9aedca165847e78d
 changes:
   behavior:
     - op: replace

--- a/specs/spec-cli/storage/changes/003_slugify-summary-in-filename.yaml
+++ b/specs/spec-cli/storage/changes/003_slugify-summary-in-filename.yaml
@@ -1,0 +1,35 @@
+format: eigen/v1
+id: chg-003
+sequence: 3
+timestamp: 2026-04-18T16:31:37Z
+type: updated
+summary: Slugify summary in change filename when summary is non-empty
+reason: |
+  61% of change files were named NNN_initial.yaml because the non-interactive
+  WriteChange path defaulted to "_initial" whenever Summary was empty at template
+  write time. The spec-agent and other callers populate Summary after the fact,
+  meaning the slug was always derived from an empty string. The fix makes
+  WriteChange (and its callers) use the slugified Summary as the filename slug
+  whenever Summary is non-empty, reserving "_initial" only for the case where
+  Summary is truly empty.
+changes:
+  behavior:
+    - op: replace
+      old: "WriteSpec marshals a SpecModule to YAML and writes it to spec.yaml with\nmode 0644. WriteChange marshals a Change to YAML and writes it to the\nchanges/ directory with filename format NNN_<slug>.yaml (zero-padded to\n3 digits) and mode 0644."
+      new: "WriteSpec marshals a SpecModule to YAML and writes it to spec.yaml with\nmode 0644. WriteChange marshals a Change to YAML and writes it to the\nchanges/ directory with filename format NNN_<slug>.yaml (zero-padded to\n3 digits) and mode 0644. The slug is derived from the Change's Summary\nfield: if Summary is non-empty, it is lowercased, all non-alphanumeric\ncharacter runs are replaced with hyphens, leading/trailing hyphens are\ntrimmed, and the result is truncated to 40 characters. If Summary is\nempty (or produces an empty slug after transformation), the slug\ndefaults to \"initial\"."
+  acceptance_criteria:
+    - id: AC-030
+      description: WriteChange uses slugified summary as filename when summary is non-empty
+      given: A Change with Sequence 4 and Summary "Add validation for empty modules"
+      when: WriteChange is called
+      then: The file is written as "004_add-validation-for-empty-modules.yaml" in the changes/ directory
+    - id: AC-031
+      description: WriteChange falls back to "initial" slug when summary is empty
+      given: A Change with Sequence 5 and an empty Summary field
+      when: WriteChange is called
+      then: The file is written as "005_initial.yaml" in the changes/ directory
+    - id: AC-032
+      description: WriteChange truncates slugified summary to 40 characters
+      given: A Change with a Summary that slugifies to more than 40 characters
+      when: WriteChange is called
+      then: The filename slug portion is at most 40 characters long

--- a/specs/spec-cli/storage/changes/003_slugify-summary-in-filename.yaml
+++ b/specs/spec-cli/storage/changes/003_slugify-summary-in-filename.yaml
@@ -15,6 +15,7 @@ reason: |
 status: compiled
 compiled_commits:
   - bd11c44249b853deb8aca5be9aedca165847e78d
+  - 82c8874d4e0e6cd42b106c64c32d9a5faeb21c31
 changes:
   behavior:
     - op: replace

--- a/specs/spec-cli/storage/changes/003_slugify-summary-in-filename.yaml
+++ b/specs/spec-cli/storage/changes/003_slugify-summary-in-filename.yaml
@@ -1,7 +1,7 @@
 format: eigen/v1
 id: chg-003
 sequence: 3
-timestamp: 2026-04-18T16:31:37Z
+timestamp: "2026-04-18T16:31:37Z"
 type: updated
 summary: Slugify summary in change filename when summary is non-empty
 reason: |
@@ -12,11 +12,25 @@ reason: |
   WriteChange (and its callers) use the slugified Summary as the filename slug
   whenever Summary is non-empty, reserving "_initial" only for the case where
   Summary is truly empty.
+status: approved
 changes:
   behavior:
     - op: replace
-      old: "WriteSpec marshals a SpecModule to YAML and writes it to spec.yaml with\nmode 0644. WriteChange marshals a Change to YAML and writes it to the\nchanges/ directory with filename format NNN_<slug>.yaml (zero-padded to\n3 digits) and mode 0644."
-      new: "WriteSpec marshals a SpecModule to YAML and writes it to spec.yaml with\nmode 0644. WriteChange marshals a Change to YAML and writes it to the\nchanges/ directory with filename format NNN_<slug>.yaml (zero-padded to\n3 digits) and mode 0644. The slug is derived from the Change's Summary\nfield: if Summary is non-empty, it is lowercased, all non-alphanumeric\ncharacter runs are replaced with hyphens, leading/trailing hyphens are\ntrimmed, and the result is truncated to 40 characters. If Summary is\nempty (or produces an empty slug after transformation), the slug\ndefaults to \"initial\"."
+      old: |-
+        WriteSpec marshals a SpecModule to YAML and writes it to spec.yaml with
+        mode 0644. WriteChange marshals a Change to YAML and writes it to the
+        changes/ directory with filename format NNN_<slug>.yaml (zero-padded to
+        3 digits) and mode 0644.
+      new: |-
+        WriteSpec marshals a SpecModule to YAML and writes it to spec.yaml with
+        mode 0644. WriteChange marshals a Change to YAML and writes it to the
+        changes/ directory with filename format NNN_<slug>.yaml (zero-padded to
+        3 digits) and mode 0644. The slug is derived from the Change's Summary
+        field: if Summary is non-empty, it is lowercased, all non-alphanumeric
+        character runs are replaced with hyphens, leading/trailing hyphens are
+        trimmed, and the result is truncated to 40 characters. If Summary is
+        empty (or produces an empty slug after transformation), the slug
+        defaults to "initial".
   acceptance_criteria:
     - id: AC-030
       description: WriteChange uses slugified summary as filename when summary is non-empty

--- a/specs/spec-cli/storage/spec.yaml
+++ b/specs/spec-cli/storage/spec.yaml
@@ -4,7 +4,7 @@ domain: spec-cli
 module: storage
 owner: eigen
 title: Storage
-status: compiled
+status: draft
 description: |
   The storage layer (eigen/internal/storage) provides filesystem-backed
   persistence for spec modules and their change histories. It exposes
@@ -26,7 +26,12 @@ behavior: |
   WriteSpec marshals a SpecModule to YAML and writes it to spec.yaml with
   mode 0644. WriteChange marshals a Change to YAML and writes it to the
   changes/ directory with filename format NNN_<slug>.yaml (zero-padded to
-  3 digits) and mode 0644.
+  3 digits) and mode 0644. The slug is derived from the Change's Summary
+  field: if Summary is non-empty, it is lowercased, all non-alphanumeric
+  character runs are replaced with hyphens, leading/trailing hyphens are
+  trimmed, and the result is truncated to 40 characters. If Summary is
+  empty (or produces an empty slug after transformation), the slug
+  defaults to "initial".
 
   NextSequence returns 1 when no changes exist or the changes directory
   is unreadable; otherwise it returns max(sequence) + 1 across all existing
@@ -195,8 +200,23 @@ acceptance_criteria:
     given: A SpecModule struct with populated fields
     when: WriteSpec is called and the resulting file bytes are inspected
     then: Every indented line in the output file is indented by a multiple of 2 spaces, not 4
+  - id: AC-030
+    description: WriteChange uses slugified summary as filename when summary is non-empty
+    given: A Change with Sequence 4 and Summary "Add validation for empty modules"
+    when: WriteChange is called
+    then: The file is written as "004_add-validation-for-empty-modules.yaml" in the changes/ directory
+  - id: AC-031
+    description: WriteChange falls back to "initial" slug when summary is empty
+    given: A Change with Sequence 5 and an empty Summary field
+    when: WriteChange is called
+    then: The file is written as "005_initial.yaml" in the changes/ directory
+  - id: AC-032
+    description: WriteChange truncates slugified summary to 40 characters
+    given: A Change with a Summary that slugifies to more than 40 characters
+    when: WriteChange is called
+    then: The filename slug portion is at most 40 characters long
 dependencies:
   - spec-cli
 technology: {}
-last_change: chg-002
-changes_count: 2
+last_change: chg-003
+changes_count: 3

--- a/specs/spec-cli/storage/spec.yaml
+++ b/specs/spec-cli/storage/spec.yaml
@@ -4,7 +4,7 @@ domain: spec-cli
 module: storage
 owner: eigen
 title: Storage
-status: draft
+status: compiled
 description: |
   The storage layer (eigen/internal/storage) provides filesystem-backed
   persistence for spec modules and their change histories. It exposes


### PR DESCRIPTION
## Summary
- **Bug #15** (`ai-agent/skill-change`): After a rejection → feedback → re-spec cycle, stale `review_comment` values on old change files triggered a false-positive REJECTED on the next approval poll. Fixed by clearing comments via `eigen spec change-comment <module> <file> ""` for each previously-commented file before re-entering the poll. Spec: `specs/ai-agent/skill-change/changes/014_initial.yaml` (AC-023).
- **Issue #31** (`spec-cli/storage`): `WriteChange` always wrote `NNN_initial.yaml` filenames. Fixed by deriving the slug internally from `ch.Summary` — slugified when non-empty, falling back to `"initial"`. Spec: `specs/spec-cli/storage/changes/003_slugify-summary-in-filename.yaml` (AC-030, AC-031, AC-032).
- **Bug #37**: Already fixed in prior compiled changes — no new work needed.

## ACs implemented
- AC-023: clear stale `review_comment` before re-entering approval poll
- AC-030: `WriteChange` uses slugified summary as filename when non-empty
- AC-031: `WriteChange` falls back to `"initial"` when summary is empty
- AC-032: slug truncated to 40 characters

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass including 3 new storage tests (AC-030/031/032)
- [x] review-agent verified all ACs

🤖 Generated with [Claude Code](https://claude.com/claude-code)