### PR TITLE
ai-agent/skill-change: persist plan to .eigen/plans/ and pass PLAN_PATH to compile-agent

### DIFF
--- a/.claude/agents/compile-agent.md
+++ b/.claude/agents/compile-agent.md
@@ -3,7 +3,7 @@ name: compile-agent
 description: Implement an eigen spec into working code, following the approved plan exactly
 ---
 
-You are the compile-agent. You receive a path to a spec and the full approved plan text inline. You implement the code exactly as specified — no more, no less.
+You are the compile-agent. You receive a path to a spec and a path to the approved plan file. You implement the code exactly as specified — no more, no less.
 
 ---
 
@@ -11,7 +11,7 @@ You are the compile-agent. You receive a path to a spec and the full approved pl
 
 - `SPEC_PATH`: path to `spec.yaml` (e.g. `specs/ai-agent/skill-change/spec.yaml`)
 - `MODULE_PATH`: the module path (e.g. `ai-agent/skill-change`)
-- `PLAN_CONTENT`: the full approved plan text, passed inline by eigen-change
+- `PLAN_PATH`: path to the approved plan file written by eigen-change (e.g. `.eigen/plans/ai-agent-skill-change-20260418T172320Z.md`)
 
 ---
 
@@ -20,7 +20,9 @@ You are the compile-agent. You receive a path to a spec and the full approved pl
 ### 1. Read the spec and plan
 
 Read `SPEC_PATH` completely. The spec's acceptance criteria define correctness.
-Read `PLAN_CONTENT` completely before writing a single line of code. The plan text is provided inline in the invocation prompt — it is not a file. The plan is the implementation contract — follow it step by step.
+Call Read on `PLAN_PATH` to load the approved plan before writing a single line of code.
+If the file at PLAN_PATH does not exist, stop immediately and report the missing path.
+The plan is the implementation contract — follow it step by step.
 
 If the plan is ambiguous or contradicts the spec, **stop and report** the ambiguity rather than guessing.
 

--- a/.claude/skills/eigen-change/SKILL.md
+++ b/.claude/skills/eigen-change/SKILL.md
@@ -158,9 +158,17 @@ Call `EnterPlanMode` presenting the draft to the user for review.
 Call `ExitPlanMode` to collect the approval decision.
 
 On approval:
-1. Store the approved plan text from ExitPlanMode.
-2. Tell the user: "Plan approved. Proceeding to implementation."
-3. Proceed to Phase 3, passing the approved plan text inline to compile-agent.
+1. Derive PLAN_PATH:
+   - Compute module slug: replace `/` with `-` in MODULE_PATH (e.g. `ai-agent/skill-change` → `ai-agent-skill-change`)
+   - Compute UTC timestamp: `date -u +%Y%m%dT%H%M%SZ`
+   - PLAN_PATH = `.eigen/plans/<module-slug>-<timestamp>.md`
+2. Write the approved plan text to PLAN_PATH:
+   ```bash
+   mkdir -p .eigen/plans
+   # Write the approved plan text returned by ExitPlanMode to PLAN_PATH
+   ```
+3. Tell the user: "Plan approved. Plan written to <PLAN_PATH>. Proceeding to implementation."
+4. Proceed to Phase 3, passing PLAN_PATH to compile-agent.
 
 On rejection: use AskUserQuestion to collect feedback text, run **Spec Feedback Loop** to update the spec, then restart Phase 2.
 
@@ -176,10 +184,9 @@ Agent(
   prompt: |
     SPEC_PATH: specs/<module-path>/spec.yaml
     MODULE_PATH: <module-path>
-    PLAN_CONTENT:
-    <approved plan text>
+    PLAN_PATH: <PLAN_PATH>
 
-    Read the spec and the PLAN_CONTENT above completely before writing any code. The plan text is provided inline — it is not a file.
+    Read the spec completely and then call Read on PLAN_PATH to load the approved plan before writing any code. If the file at PLAN_PATH does not exist, stop and report the missing path.
     Implement following the plan step by step.
     Build with `go build ./...` from the `eigen/` subdirectory of the repo root.
     Verify each acceptance criterion.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 eigen/eigen
 .idea
 .claude/settings.local.json
+.eigen/plans/

--- a/eigen/cmd/agents/compile-agent.md
+++ b/eigen/cmd/agents/compile-agent.md
@@ -3,7 +3,7 @@ name: compile-agent
 description: Implement an eigen spec into working code, following the approved plan exactly
 ---
 
-You are the compile-agent. You receive a path to a spec and the full approved plan text inline. You implement the code exactly as specified — no more, no less.
+You are the compile-agent. You receive a path to a spec and a path to the approved plan file. You implement the code exactly as specified — no more, no less.
 
 ---
 
@@ -11,7 +11,7 @@ You are the compile-agent. You receive a path to a spec and the full approved pl
 
 - `SPEC_PATH`: path to `spec.yaml` (e.g. `specs/ai-agent/skill-change/spec.yaml`)
 - `MODULE_PATH`: the module path (e.g. `ai-agent/skill-change`)
-- `PLAN_CONTENT`: the full approved plan text, passed inline by eigen-change
+- `PLAN_PATH`: path to the approved plan file written by eigen-change (e.g. `.eigen/plans/ai-agent-skill-change-20260418T172320Z.md`)
 
 ---
 
@@ -20,7 +20,9 @@ You are the compile-agent. You receive a path to a spec and the full approved pl
 ### 1. Read the spec and plan
 
 Read `SPEC_PATH` completely. The spec's acceptance criteria define correctness.
-Read `PLAN_CONTENT` completely before writing a single line of code. The plan text is provided inline in the invocation prompt — it is not a file. The plan is the implementation contract — follow it step by step.
+Call Read on `PLAN_PATH` to load the approved plan before writing a single line of code.
+If the file at PLAN_PATH does not exist, stop immediately and report the missing path.
+The plan is the implementation contract — follow it step by step.
 
 If the plan is ambiguous or contradicts the spec, **stop and report** the ambiguity rather than guessing.
 

--- a/eigen/cmd/skills/eigen-change.md
+++ b/eigen/cmd/skills/eigen-change.md
@@ -158,9 +158,17 @@ Call `EnterPlanMode` presenting the draft to the user for review.
 Call `ExitPlanMode` to collect the approval decision.
 
 On approval:
-1. Store the approved plan text from ExitPlanMode.
-2. Tell the user: "Plan approved. Proceeding to implementation."
-3. Proceed to Phase 3, passing the approved plan text inline to compile-agent.
+1. Derive PLAN_PATH:
+   - Compute module slug: replace `/` with `-` in MODULE_PATH (e.g. `ai-agent/skill-change` → `ai-agent-skill-change`)
+   - Compute UTC timestamp: `date -u +%Y%m%dT%H%M%SZ`
+   - PLAN_PATH = `.eigen/plans/<module-slug>-<timestamp>.md`
+2. Write the approved plan text to PLAN_PATH:
+   ```bash
+   mkdir -p .eigen/plans
+   # Write the approved plan text returned by ExitPlanMode to PLAN_PATH
+   ```
+3. Tell the user: "Plan approved. Plan written to <PLAN_PATH>. Proceeding to implementation."
+4. Proceed to Phase 3, passing PLAN_PATH to compile-agent.
 
 On rejection: use AskUserQuestion to collect feedback text, run **Spec Feedback Loop** to update the spec, then restart Phase 2.
 
@@ -176,10 +184,9 @@ Agent(
   prompt: |
     SPEC_PATH: specs/<module-path>/spec.yaml
     MODULE_PATH: <module-path>
-    PLAN_CONTENT:
-    <approved plan text>
+    PLAN_PATH: <PLAN_PATH>
 
-    Read the spec and the PLAN_CONTENT above completely before writing any code. The plan text is provided inline — it is not a file.
+    Read the spec completely and then call Read on PLAN_PATH to load the approved plan before writing any code. If the file at PLAN_PATH does not exist, stop and report the missing path.
     Implement following the plan step by step.
     Build with `go build ./...` from the `eigen/` subdirectory of the repo root.
     Verify each acceptance criterion.

--- a/specs/ai-agent/skill-change/changes/015_persist-plan-to-file.yaml
+++ b/specs/ai-agent/skill-change/changes/015_persist-plan-to-file.yaml
@@ -1,0 +1,82 @@
+format: eigen/v1
+id: chg-015
+sequence: 15
+timestamp: "2026-04-18T17:23:20Z"
+author: alexander
+type: updated
+summary: Persist approved plan to .eigen/plans/ file and pass file path to compile-agent
+reason: |
+  Currently the approved plan text is passed inline as PLAN_CONTENT in the compile-agent
+  prompt. This has three downsides: (1) long plans inflate prompt size and risk
+  paraphrasing or truncation when the skill constructs the Agent invocation string;
+  (2) there is no audit trail of what plan was actually executed; (3) a fresh compile
+  invocation cannot recover the plan without re-running the plan phase.
+
+  Persisting the plan to .eigen/plans/<module-slug>-<timestamp>.md before launching
+  compile-agent solves all three: the file is the single source of truth, the prompt
+  is a compact path reference, and the file remains on disk as an audit artifact.
+  The compile-agent reads the plan from the path rather than from inline content.
+changes:
+  acceptance_criteria:
+    - id: AC-003
+      description: |
+        Phase 2 — Plan — runs as follows:
+        (1) eigen-change launches plan-agent (read-only subagent) with SPEC_PATH, MODULE_PATH,
+            and BRANCH. plan-agent explores the codebase and returns a comprehensive draft plan
+            as text output. plan-agent does NOT enter plan mode or write any files.
+        (2) eigen-change (main conversation) calls EnterPlanMode, presenting the draft plan
+            text to the user via the plan mode UI.
+        (3) User reviews the plan in plan mode UI and either approves or comments/rejects.
+        (4) eigen-change calls ExitPlanMode to collect approval status and the approved plan text.
+        (5) On approval: eigen-change writes the plan text to
+            .eigen/plans/<module-slug>-<ISO-timestamp>.md (creating the directory if absent),
+            stores the path as PLAN_PATH, and proceeds to Phase 3 passing PLAN_PATH to
+            compile-agent. The filename slug replaces `/` with `-` in MODULE_PATH and uses
+            UTC timestamp in YYYYMMDDTHHMMSSZ form. No plan commit is made. Plan files are
+            retained after compilation as an audit artifact and are excluded from git via
+            .gitignore.
+        (6) On rejection: eigen-change collects feedback via AskUserQuestion, runs the Spec
+            Feedback Loop (spec-agent writes a new change file), then restarts Phase 2 from
+            step (1).
+      given: The spec phase has been approved
+      when: eigen-change launches plan-agent with SPEC_PATH and MODULE_PATH
+      then: |
+        plan-agent returns a draft plan as text; eigen-change presents it in plan mode UI for
+        user approval. On approval, eigen-change persists the plan to
+        .eigen/plans/<module-slug>-<timestamp>.md and stores the path as PLAN_PATH.
+    - id: AC-004
+      description: |
+        After plan approval, eigen-change writes the approved plan text to
+        `.eigen/plans/<module-slug>-<ISO-timestamp>.md` (creating the directory if needed),
+        stores the path as PLAN_PATH, and passes PLAN_PATH (not inline content) to
+        compile-agent alongside SPEC_PATH and MODULE_PATH. compile-agent reads the plan from
+        the file before implementing. Plan files are retained after compilation as an audit
+        artifact and are not deleted. The .eigen/plans/ directory is gitignored.
+      given: The plan has been approved by the user
+      when: eigen-change launches compile-agent
+      then: |
+        eigen-change writes the plan to .eigen/plans/<slug>-<timestamp>.md, passes
+        PLAN_PATH to compile-agent, and compile-agent reads the plan from the file at
+        that path. The plan file persists after compilation as an audit artifact.
+    - id: AC-024
+      description: |
+        The .eigen/plans/ directory is added to .gitignore so plan files are never
+        accidentally committed. The directory is created at runtime by eigen-change
+        before writing the first plan file; no pre-existing directory is required.
+      given: eigen-change is about to write a plan file
+      when: It creates .eigen/plans/ and writes the file
+      then: |
+        The .eigen/plans/ directory exists on disk (created if absent) and is listed in
+        .gitignore. The plan file is written successfully and is not staged or committed.
+    - id: AC-025
+      description: |
+        compile-agent is updated to accept PLAN_PATH (a file path) instead of PLAN_CONTENT
+        (inline text). The agent reads the plan by calling Read on PLAN_PATH before
+        implementing. The compile-agent definition (both embedded source and .claude/ copy)
+        no longer references PLAN_CONTENT.
+      given: compile-agent receives an invocation prompt containing PLAN_PATH
+      when: compile-agent begins its workflow
+      then: |
+        compile-agent calls Read on PLAN_PATH to load the plan text, then proceeds with
+        implementation. If the file at PLAN_PATH does not exist, compile-agent stops and
+        reports the missing path to eigen-change rather than guessing at the plan.

--- a/specs/ai-agent/skill-change/changes/015_persist-plan-to-file.yaml
+++ b/specs/ai-agent/skill-change/changes/015_persist-plan-to-file.yaml
@@ -16,6 +16,7 @@ reason: |
   compile-agent solves all three: the file is the single source of truth, the prompt
   is a compact path reference, and the file remains on disk as an audit artifact.
   The compile-agent reads the plan from the path rather than from inline content.
+status: approved
 changes:
   acceptance_criteria:
     - id: AC-003

--- a/specs/ai-agent/skill-change/changes/015_persist-plan-to-file.yaml
+++ b/specs/ai-agent/skill-change/changes/015_persist-plan-to-file.yaml
@@ -16,7 +16,9 @@ reason: |
   compile-agent solves all three: the file is the single source of truth, the prompt
   is a compact path reference, and the file remains on disk as an audit artifact.
   The compile-agent reads the plan from the path rather than from inline content.
-status: approved
+status: compiled
+compiled_commits:
+  - 6556db7c79312760a8c16a5eaae9bab2649be8be
 changes:
   acceptance_criteria:
     - id: AC-003

--- a/specs/ai-agent/skill-change/spec.yaml
+++ b/specs/ai-agent/skill-change/spec.yaml
@@ -4,6 +4,7 @@ domain: ai-agent
 module: skill-change
 owner: alexander
 title: Unified `change` skill — orchestrates spec → plan → compile workflow
+status: compiled
 description: |-
   Refine the feedback loop: when user rejects output at any phase and provides feedback,
   the skill immediately invokes spec-agent to write a new change file incorporating the feedback,

--- a/specs/ai-agent/skill-change/spec.yaml
+++ b/specs/ai-agent/skill-change/spec.yaml
@@ -4,7 +4,6 @@ domain: ai-agent
 module: skill-change
 owner: alexander
 title: Unified `change` skill — orchestrates spec → plan → compile workflow
-status: compiled
 description: |-
   Refine the feedback loop: when user rejects output at any phase and provides feedback,
   the skill immediately invokes spec-agent to write a new change file incorporating the feedback,
@@ -105,23 +104,36 @@ acceptance_criteria:
           text to the user via the plan mode UI.
       (3) User reviews the plan in plan mode UI and either approves or comments/rejects.
       (4) eigen-change calls ExitPlanMode to collect approval status and the approved plan text.
-      (5) On approval: eigen-change proceeds directly to Phase 3, passing the approved plan
-          text inline to compile-agent. No plan.md file is written and no plan commit is made.
+      (5) On approval: eigen-change writes the plan text to
+          .eigen/plans/<module-slug>-<ISO-timestamp>.md (creating the directory if absent),
+          stores the path as PLAN_PATH, and proceeds to Phase 3 passing PLAN_PATH to
+          compile-agent. The filename slug replaces `/` with `-` in MODULE_PATH and uses
+          UTC timestamp in YYYYMMDDTHHMMSSZ form. No plan commit is made. Plan files are
+          retained after compilation as an audit artifact and are excluded from git via
+          .gitignore.
       (6) On rejection: eigen-change collects feedback via AskUserQuestion, runs the Spec
           Feedback Loop (spec-agent writes a new change file), then restarts Phase 2 from
           step (1).
     given: The spec phase has been approved
     when: eigen-change launches plan-agent with SPEC_PATH and MODULE_PATH
-    then: plan-agent returns a draft plan as text; eigen-change presents it in plan mode UI for user approval
+    then: |
+      plan-agent returns a draft plan as text; eigen-change presents it in plan mode UI for
+      user approval. On approval, eigen-change persists the plan to
+      .eigen/plans/<module-slug>-<timestamp>.md and stores the path as PLAN_PATH.
   - id: AC-004
     description: |
-      After plan approval, compile-agent is called with the approved plan text passed as
-      inline content (not a file path) alongside SPEC_PATH and MODULE_PATH.
-      Compile-agent implements code and makes small atomic commits. After completion, user
-      can review diff and approve final result.
+      After plan approval, eigen-change writes the approved plan text to
+      `.eigen/plans/<module-slug>-<ISO-timestamp>.md` (creating the directory if needed),
+      stores the path as PLAN_PATH, and passes PLAN_PATH (not inline content) to
+      compile-agent alongside SPEC_PATH and MODULE_PATH. compile-agent reads the plan from
+      the file before implementing. Plan files are retained after compilation as an audit
+      artifact and are not deleted. The .eigen/plans/ directory is gitignored.
     given: The plan has been approved by the user
-    when: eigen-change launches compile-agent with the approved plan text inline
-    then: compile-agent implements the code with atomic commits and reports completion
+    when: eigen-change launches compile-agent
+    then: |
+      eigen-change writes the plan to .eigen/plans/<slug>-<timestamp>.md, passes
+      PLAN_PATH to compile-agent, and compile-agent reads the plan from the file at
+      that path. The plan file persists after compilation as an audit artifact.
   - id: AC-005
     description: |
       Skill handles all Agent tool invocation, approval prompts, feedback loops, and branch
@@ -308,6 +320,28 @@ acceptance_criteria:
       file that previously had a review_comment, clearing the stale value before the
       next poll begins. The next poll only detects a rejection if the user writes a
       new comment in the review UI.
+  - id: AC-024
+    description: |
+      The .eigen/plans/ directory is added to .gitignore so plan files are never
+      accidentally committed. The directory is created at runtime by eigen-change
+      before writing the first plan file; no pre-existing directory is required.
+    given: eigen-change is about to write a plan file
+    when: It creates .eigen/plans/ and writes the file
+    then: |
+      The .eigen/plans/ directory exists on disk (created if absent) and is listed in
+      .gitignore. The plan file is written successfully and is not staged or committed.
+  - id: AC-025
+    description: |
+      compile-agent is updated to accept PLAN_PATH (a file path) instead of PLAN_CONTENT
+      (inline text). The agent reads the plan by calling Read on PLAN_PATH before
+      implementing. The compile-agent definition (both embedded source and .claude/ copy)
+      no longer references PLAN_CONTENT.
+    given: compile-agent receives an invocation prompt containing PLAN_PATH
+    when: compile-agent begins its workflow
+    then: |
+      compile-agent calls Read on PLAN_PATH to load the plan text, then proceeds with
+      implementation. If the file at PLAN_PATH does not exist, compile-agent stops and
+      reports the missing path to eigen-change rather than guessing at the plan.
 dependencies: []
 technology:
   AgentTypes: spec-subagent, plan-subagent, compile-subagent
@@ -316,5 +350,5 @@ technology:
     Specs: changes/*.yaml + spec.yaml (eigen-spec format)
     Plans: temporary plan mode UI only (no file written)
     Code: git commits
-last_change: chg-014
-changes_count: 14
+last_change: chg-015
+changes_count: 15


### PR DESCRIPTION
## Summary
- Replaces inline `PLAN_CONTENT` passing with file-based plan persistence
- eigen-change writes the approved plan to `.eigen/plans/<module-slug>-<timestamp>.md` on approval and passes `PLAN_PATH` to compile-agent
- compile-agent reads the plan from the file path rather than reconstructing from prompt text
- `.eigen/plans/` added to `.gitignore` (plans are audit artifacts, not committed)

## Spec
- `specs/ai-agent/skill-change/spec.yaml`
- Change: `015_persist-plan-to-file.yaml`

## ACs implemented
- AC-003: Phase 2 on approval writes plan file and stores PLAN_PATH
- AC-004: compile-agent receives PLAN_PATH, reads from file, stops if missing
- AC-024: `.eigen/plans/` gitignored; directory created at runtime
- AC-025: compile-agent definition updated to PLAN_PATH (zero PLAN_CONTENT refs in impl files)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)