### PR TITLE
ai-agent/skill-change: add Phase 0 shaping, Phase 1b spec review, and agent tool allowlists

### DIFF
--- a/.claude/agents/compile-agent.md
+++ b/.claude/agents/compile-agent.md
@@ -1,6 +1,13 @@
 ---
 name: compile-agent
 description: Implement an eigen spec into working code, following the approved plan exactly
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
 ---
 
 You are the compile-agent. You receive a path to a spec and a path to the approved plan file. You implement the code exactly as specified — no more, no less.

--- a/.claude/agents/plan-agent.md
+++ b/.claude/agents/plan-agent.md
@@ -1,6 +1,11 @@
 ---
 name: plan-agent
 description: Research codebase and return a draft implementation plan as text — read-only, no plan mode, no file writes
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
 ---
 
 You are the plan-agent. You receive a spec module path, explore the codebase, design a detailed implementation plan, and return the plan as structured markdown text. You do not enter plan mode, write files, or make commits.

--- a/.claude/agents/review-agent.md
+++ b/.claude/agents/review-agent.md
@@ -1,6 +1,11 @@
 ---
 name: review-agent
 description: Verify that a compiled implementation satisfies every acceptance criterion in the spec — read-only, no file writes
+tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
 ---
 
 You are the review-agent. You receive a spec module path, read the spec and the compiled code, and return a structured compliance report. You do not write files, make commits, or modify anything.

--- a/.claude/agents/spec-agent.md
+++ b/.claude/agents/spec-agent.md
@@ -1,6 +1,14 @@
 ---
 name: spec-agent
 description: Spec a feature by asking clarifying questions and writing eigen-format change files
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+  - AskUserQuestion
 ---
 
 You are the spec-agent. You write precise, well-reasoned specs in eigen's change file format. You are invoked in two modes: **initial** (given a feature description) and **feedback** (given user feedback to incorporate into an existing spec).

--- a/.claude/skills/eigen-change/SKILL.md
+++ b/.claude/skills/eigen-change/SKILL.md
@@ -36,6 +36,33 @@ Ask the user which module path to use (e.g. `ai-agent/skill-change`) or derive i
 
 ---
 
+## Phase 0 — Shaping
+
+Before invoking spec-agent, ask the user clarifying questions inline in the main conversation thread using AskUserQuestion. The goal is to surface ambiguities, edge cases, or missing constraints that would otherwise block the spec-agent or produce a spec that needs immediate revision.
+
+**Rules:**
+- Ask as many questions as genuinely needed — there is no cap.
+- Only ask a question when the answer will influence the spec or implementation. Questions whose answers would not change anything must be omitted.
+- Phase 0 is always mandatory — there is no skip flag or argument to bypass it.
+- Ask questions one at a time, sequentially.
+
+**Collecting answers:**
+After all questions have been answered, collect them into a "Shaping context" block:
+
+```
+Shaping context:
+Q: <question 1>
+A: <answer 1>
+
+Q: <question 2>
+A: <answer 2>
+...
+```
+
+This block is passed verbatim to the spec-agent invocation prompt in Phase 1.
+
+---
+
 ## Phase 1 — Spec
 
 Launch the spec-agent to produce the spec:
@@ -48,6 +75,8 @@ Agent(
 
     Feature description: <description from user>
     Module path: <module-path>
+
+    <Shaping context block from Phase 0 — paste verbatim here>
 
     Ask the user clarifying questions, explore the codebase, write the spec change files,
     run `eigen spec project <module-path>`, and validate.
@@ -64,6 +93,19 @@ After the agent completes:
 2. Commit the spec files:
      git add specs/<module-path>/
      git commit -m "spec(<module>): <summary from spec-agent report>"
+
+### Phase 1b — Spec Review
+
+After committing the spec and before opening the review UI poll, review the written spec inline:
+
+1. Read `specs/<module-path>/spec.yaml` (the projected spec).
+2. Identify concerns: edge cases not covered by ACs, ambiguities in the behavior description, missing error handling, unclear given/when/then, contradictions between ACs, etc.
+3. For each concern, call AskUserQuestion with that single concern and wait for the user's response before moving to the next concern. Present concerns one at a time, sequentially.
+4. After each user response:
+   - If the response indicates a spec change is needed (e.g. "yes, add that", "good catch, include it", or any substantive correction): run the **Spec Feedback Loop** with the user's response as feedback, then **restart Phase 1b from step 1** against the revised spec.
+   - If the response indicates no change is needed (e.g. "that's fine", "out of scope", "not needed"): continue to the next concern.
+5. After all concerns have been presented and resolved with no further spec changes, proceed to step 3 (the review UI poll).
+6. If no concerns are identified, proceed directly to step 3.
 
 3. Tell the user: "Spec written. Open http://localhost:7171 to review and approve/reject in the browser. I'll proceed automatically when you submit."
 

--- a/eigen/cmd/agents/compile-agent.md
+++ b/eigen/cmd/agents/compile-agent.md
@@ -1,6 +1,13 @@
 ---
 name: compile-agent
 description: Implement an eigen spec into working code, following the approved plan exactly
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
 ---
 
 You are the compile-agent. You receive a path to a spec and a path to the approved plan file. You implement the code exactly as specified — no more, no less.

--- a/eigen/cmd/agents/plan-agent.md
+++ b/eigen/cmd/agents/plan-agent.md
@@ -1,6 +1,11 @@
 ---
 name: plan-agent
 description: Research codebase and return a draft implementation plan as text — read-only, no plan mode, no file writes
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
 ---
 
 You are the plan-agent. You receive a spec module path, explore the codebase, design a detailed implementation plan, and return the plan as structured markdown text. You do not enter plan mode, write files, or make commits.

--- a/eigen/cmd/agents/review-agent.md
+++ b/eigen/cmd/agents/review-agent.md
@@ -1,6 +1,11 @@
 ---
 name: review-agent
 description: Verify that a compiled implementation satisfies every acceptance criterion in the spec — read-only, no file writes
+tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
 ---
 
 You are the review-agent. You receive a spec module path, read the spec and the compiled code, and return a structured compliance report. You do not write files, make commits, or modify anything.

--- a/eigen/cmd/agents/spec-agent.md
+++ b/eigen/cmd/agents/spec-agent.md
@@ -1,6 +1,14 @@
 ---
 name: spec-agent
 description: Spec a feature by asking clarifying questions and writing eigen-format change files
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+  - AskUserQuestion
 ---
 
 You are the spec-agent. You write precise, well-reasoned specs in eigen's change file format. You are invoked in two modes: **initial** (given a feature description) and **feedback** (given user feedback to incorporate into an existing spec).

--- a/eigen/cmd/skills/eigen-change.md
+++ b/eigen/cmd/skills/eigen-change.md
@@ -36,6 +36,33 @@ Ask the user which module path to use (e.g. `ai-agent/skill-change`) or derive i
 
 ---
 
+## Phase 0 — Shaping
+
+Before invoking spec-agent, ask the user clarifying questions inline in the main conversation thread using AskUserQuestion. The goal is to surface ambiguities, edge cases, or missing constraints that would otherwise block the spec-agent or produce a spec that needs immediate revision.
+
+**Rules:**
+- Ask as many questions as genuinely needed — there is no cap.
+- Only ask a question when the answer will influence the spec or implementation. Questions whose answers would not change anything must be omitted.
+- Phase 0 is always mandatory — there is no skip flag or argument to bypass it.
+- Ask questions one at a time, sequentially.
+
+**Collecting answers:**
+After all questions have been answered, collect them into a "Shaping context" block:
+
+```
+Shaping context:
+Q: <question 1>
+A: <answer 1>
+
+Q: <question 2>
+A: <answer 2>
+...
+```
+
+This block is passed verbatim to the spec-agent invocation prompt in Phase 1.
+
+---
+
 ## Phase 1 — Spec
 
 Launch the spec-agent to produce the spec:
@@ -48,6 +75,8 @@ Agent(
 
     Feature description: <description from user>
     Module path: <module-path>
+
+    <Shaping context block from Phase 0 — paste verbatim here>
 
     Ask the user clarifying questions, explore the codebase, write the spec change files,
     run `eigen spec project <module-path>`, and validate.
@@ -64,6 +93,19 @@ After the agent completes:
 2. Commit the spec files:
      git add specs/<module-path>/
      git commit -m "spec(<module>): <summary from spec-agent report>"
+
+### Phase 1b — Spec Review
+
+After committing the spec and before opening the review UI poll, review the written spec inline:
+
+1. Read `specs/<module-path>/spec.yaml` (the projected spec).
+2. Identify concerns: edge cases not covered by ACs, ambiguities in the behavior description, missing error handling, unclear given/when/then, contradictions between ACs, etc.
+3. For each concern, call AskUserQuestion with that single concern and wait for the user's response before moving to the next concern. Present concerns one at a time, sequentially.
+4. After each user response:
+   - If the response indicates a spec change is needed (e.g. "yes, add that", "good catch, include it", or any substantive correction): run the **Spec Feedback Loop** with the user's response as feedback, then **restart Phase 1b from step 1** against the revised spec.
+   - If the response indicates no change is needed (e.g. "that's fine", "out of scope", "not needed"): continue to the next concern.
+5. After all concerns have been presented and resolved with no further spec changes, proceed to step 3 (the review UI poll).
+6. If no concerns are identified, proceed directly to step 3.
 
 3. Tell the user: "Spec written. Open http://localhost:7171 to review and approve/reject in the browser. I'll proceed automatically when you submit."
 

--- a/specs/ai-agent/skill-change/changes/016_shaping-and-spec-review-phases.yaml
+++ b/specs/ai-agent/skill-change/changes/016_shaping-and-spec-review-phases.yaml
@@ -1,7 +1,7 @@
 format: eigen/v1
 id: chg-016
 sequence: 16
-timestamp: 2026-04-18T18:04:52Z
+timestamp: "2026-04-18T18:04:52Z"
 author: alexander
 type: updated
 summary: Add Phase 0 (Shaping) and Phase 1b (Spec Review) clarification sub-phases, and add AskUserQuestion to agent tool allowlists
@@ -29,6 +29,7 @@ reason: |
   inside those agents, blocking them from asking clarifying questions of the user directly.
   Adding a tools: field to each agent's frontmatter listing the tools the agent needs
   (including AskUserQuestion where appropriate) fixes this bootstrapping gap.
+status: approved
 changes:
   behavior:
     - op: prepend
@@ -49,11 +50,11 @@ changes:
         Feedback Loop runs (spec-agent writes a new change file, re-projects), and Phase 1b
         restarts from scratch against the revised spec. If no concerns are identified,
         eigen-change enters the review UI poll immediately.
-
     - op: replace
-      old: "The approval polling loop checks the HTTP status code"
-      new: "After Phase 1b confirms the user is satisfied, the approval polling loop checks the HTTP status code"
-
+      old: |-
+        The approval polling loop checks the HTTP status code
+      new: |-
+        After Phase 1b confirms the user is satisfied, the approval polling loop checks the HTTP status code
   acceptance_criteria:
     - id: AC-026
       description: |

--- a/specs/ai-agent/skill-change/changes/016_shaping-and-spec-review-phases.yaml
+++ b/specs/ai-agent/skill-change/changes/016_shaping-and-spec-review-phases.yaml
@@ -29,7 +29,9 @@ reason: |
   inside those agents, blocking them from asking clarifying questions of the user directly.
   Adding a tools: field to each agent's frontmatter listing the tools the agent needs
   (including AskUserQuestion where appropriate) fixes this bootstrapping gap.
-status: approved
+status: compiled
+compiled_commits:
+  - 2e4687622a807d9578ba6639755b41ea59c8c713
 changes:
   behavior:
     - op: prepend

--- a/specs/ai-agent/skill-change/changes/016_shaping-and-spec-review-phases.yaml
+++ b/specs/ai-agent/skill-change/changes/016_shaping-and-spec-review-phases.yaml
@@ -1,0 +1,111 @@
+format: eigen/v1
+id: chg-016
+sequence: 16
+timestamp: 2026-04-18T18:04:52Z
+author: alexander
+type: updated
+summary: Add Phase 0 (Shaping) and Phase 1b (Spec Review) clarification sub-phases, and add AskUserQuestion to agent tool allowlists
+reason: |
+  The current workflow jumps straight into spec writing after the user provides a feature
+  description. This often leads to wasted spec cycles when the description is ambiguous,
+  the scope is unclear, or the user's intent does not match what the agent produces.
+
+  Two new inline clarification sub-phases address this:
+  - Phase 0 (Shaping): runs before spec-agent, lets the main conversation ask the user
+    clarifying questions via AskUserQuestion (as many as genuinely needed, but only when
+    the answer will influence the spec or implementation). Always mandatory — no skip flag.
+  - Phase 1b (Spec Review): runs after spec-agent returns but before the browser-based
+    review UI poll. The main conversation reads the projected spec.yaml, identifies concerns
+    (edge cases, ambiguities, missing error handling, etc.), and presents each concern as a
+    separate sequential AskUserQuestion. Only when all concerns are resolved does eigen-change
+    enter the review UI poll.
+
+  Both phases run inline in the main eigen-change conversation thread; no new subagent
+  files are needed. Shaping answers are passed verbatim as additional context in the
+  spec-agent invocation prompt alongside the feature description.
+
+  Additionally, spec-agent (and other agent definition files) currently lack an explicit
+  tools allowlist in their YAML frontmatter. This means AskUserQuestion is unavailable
+  inside those agents, blocking them from asking clarifying questions of the user directly.
+  Adding a tools: field to each agent's frontmatter listing the tools the agent needs
+  (including AskUserQuestion where appropriate) fixes this bootstrapping gap.
+changes:
+  behavior:
+    - op: prepend
+      text: |
+        Phase 0 — Shaping runs inline in the main conversation before spec-agent is invoked.
+        eigen-change uses AskUserQuestion to ask the user clarifying questions that
+        disambiguate scope, edge cases, or constraints. There is no cap on the number of
+        questions, but eigen-change must only ask when the answer will influence the spec or
+        implementation — noise-generating questions are omitted. Phase 0 is always mandatory;
+        there is no skip flag. The answers are collected and passed verbatim as additional
+        context in the spec-agent invocation prompt alongside the original feature description.
+
+        Phase 1b — Spec Review runs inline in the main conversation after spec-agent writes
+        and projects the spec but before the browser-based review UI poll begins. eigen-change
+        reads the projected spec.yaml and identifies concerns (edge cases, ambiguities, missing
+        error handling, etc.). Each concern is presented as a separate sequential AskUserQuestion.
+        The user addresses each in turn. If any response triggers a spec revision, the Spec
+        Feedback Loop runs (spec-agent writes a new change file, re-projects), and Phase 1b
+        restarts from scratch against the revised spec. If no concerns are identified,
+        eigen-change enters the review UI poll immediately.
+
+    - op: replace
+      old: "The approval polling loop checks the HTTP status code"
+      new: "After Phase 1b confirms the user is satisfied, the approval polling loop checks the HTTP status code"
+
+  acceptance_criteria:
+    - id: AC-026
+      description: |
+        Phase 0 — Shaping: before invoking spec-agent, eigen-change asks the user clarifying
+        questions via AskUserQuestion in the main conversation thread. Questions target scope
+        ambiguities, edge cases, or missing constraints that would block the spec-agent.
+        There is no cap on the number of questions — eigen-change asks as many as genuinely
+        needed. However, eigen-change must only ask a question when the answer will actually
+        influence the spec or implementation; questions whose answers would not change anything
+        must be omitted to keep the conversation context clean. Phase 0 is always mandatory —
+        there is no skip flag or invocation argument to bypass it.
+      given: A user invokes /eigen-change with a feature description
+      when: Phase 0 runs before spec-agent is launched
+      then: |
+        eigen-change asks the user clarifying questions via AskUserQuestion — as many as
+        genuinely needed, but only questions whose answers will influence the spec or
+        implementation. Questions whose answers would not change the spec or plan are skipped.
+        The user's answers are collected and appended verbatim as "Shaping context" in the
+        spec-agent invocation prompt alongside the original feature description.
+    - id: AC-027
+      description: |
+        Phase 1b — Spec Review: after spec-agent writes and projects the spec (and before
+        the review UI poll begins), eigen-change reads the projected spec.yaml and identifies
+        concerns — edge cases, ambiguities, missing error handling, unclear acceptance criteria,
+        etc. Each concern is presented to the user as a separate, sequential AskUserQuestion.
+        The user addresses each concern in turn. After all concerns have been raised and
+        resolved, eigen-change enters the review UI poll. If the user's response to any concern
+        indicates a spec change is needed, the Spec Feedback Loop runs (spec-agent writes a new
+        change file, re-projects), and Phase 1b restarts from the beginning with the updated spec.
+      given: spec-agent has completed writing and projecting the spec
+      when: Phase 1b runs before the review UI poll
+      then: |
+        eigen-change reads the projected spec.yaml and derives a list of concerns. For each
+        concern, it calls AskUserQuestion with that single concern before moving to the next.
+        Only after every concern has been presented and the user has responded to each does
+        eigen-change enter the review UI poll. If any response triggers a spec revision, the
+        Spec Feedback Loop runs and Phase 1b repeats from scratch against the revised spec.
+        If no concerns are identified, eigen-change enters the review UI poll immediately.
+    - id: AC-028
+      description: |
+        Agent tool allowlists: every agent definition file (spec-agent.md, plan-agent.md,
+        compile-agent.md, review-agent.md) gains an explicit tools: field in its YAML
+        frontmatter listing only the tools that agent needs. spec-agent's allowlist includes
+        AskUserQuestion so it can ask clarifying questions of the user directly. plan-agent
+        and review-agent do not receive AskUserQuestion because they are read-only research
+        agents that return text to the caller rather than interacting with the user.
+        compile-agent does not receive AskUserQuestion; if ambiguous it stops and reports.
+      given: An agent definition file is deployed via eigen scaffold
+      when: The agent runs inside a subagent thread
+      then: |
+        The agent's frontmatter tools: field lists only the tools it needs. spec-agent's
+        list includes AskUserQuestion. plan-agent and review-agent do not have
+        AskUserQuestion. compile-agent does not have AskUserQuestion. The generated
+        .claude/agents/<name>.md copies match the embedded source files in
+        eigen/cmd/agents/<name>.md.

--- a/specs/ai-agent/skill-change/spec.yaml
+++ b/specs/ai-agent/skill-change/spec.yaml
@@ -4,6 +4,7 @@ domain: ai-agent
 module: skill-change
 owner: alexander
 title: Unified `change` skill — orchestrates spec → plan → compile workflow
+status: compiled
 description: |-
   Refine the feedback loop: when user rejects output at any phase and provides feedback,
   the skill immediately invokes spec-agent to write a new change file incorporating the feedback,

--- a/specs/ai-agent/skill-change/spec.yaml
+++ b/specs/ai-agent/skill-change/spec.yaml
@@ -4,7 +4,6 @@ domain: ai-agent
 module: skill-change
 owner: alexander
 title: Unified `change` skill — orchestrates spec → plan → compile workflow
-status: compiled
 description: |-
   Refine the feedback loop: when user rejects output at any phase and provides feedback,
   the skill immediately invokes spec-agent to write a new change file incorporating the feedback,
@@ -22,6 +21,22 @@ description: |-
   rejection, eigen-change commits the feedback change file after the next spec-agent run
   completes.
 behavior: |
+  Phase 0 — Shaping runs inline in the main conversation before spec-agent is invoked.
+  eigen-change uses AskUserQuestion to ask the user clarifying questions that
+  disambiguate scope, edge cases, or constraints. There is no cap on the number of
+  questions, but eigen-change must only ask when the answer will influence the spec or
+  implementation — noise-generating questions are omitted. Phase 0 is always mandatory;
+  there is no skip flag. The answers are collected and passed verbatim as additional
+  context in the spec-agent invocation prompt alongside the original feature description.
+
+  Phase 1b — Spec Review runs inline in the main conversation after spec-agent writes
+  and projects the spec but before the browser-based review UI poll begins. eigen-change
+  reads the projected spec.yaml and identifies concerns (edge cases, ambiguities, missing
+  error handling, etc.). Each concern is presented as a separate sequential AskUserQuestion.
+  The user addresses each in turn. If any response triggers a spec revision, the Spec
+  Feedback Loop runs (spec-agent writes a new change file, re-projects), and Phase 1b
+  restarts from scratch against the revised spec. If no concerns are identified,
+  eigen-change enters the review UI poll immediately.
   The /change skill orchestrates spec -> plan -> compile. At setup it fetches the
   latest main branch (`git fetch origin main`) and creates a new feature branch from it
   (`git checkout -b <feature-branch> origin/main`). The skill does NOT continue on the
@@ -33,7 +48,7 @@ behavior: |
   eigen serve API as a ?worktree= query parameter so modules are correctly disambiguated
   when the same module path exists in multiple worktrees.
 
-  The approval polling loop checks the HTTP status code of each curl response before
+  After Phase 1b confirms the user is satisfied, the approval polling loop checks the HTTP status code of each curl response before
   attempting JSON parsing. If the response is not HTTP 200, the loop logs a diagnostic
   message with the status code and response body. After a configurable number of
   consecutive failures (default 5), the loop exits with an error message instead of
@@ -343,6 +358,60 @@ acceptance_criteria:
       compile-agent calls Read on PLAN_PATH to load the plan text, then proceeds with
       implementation. If the file at PLAN_PATH does not exist, compile-agent stops and
       reports the missing path to eigen-change rather than guessing at the plan.
+  - id: AC-026
+    description: |
+      Phase 0 — Shaping: before invoking spec-agent, eigen-change asks the user clarifying
+      questions via AskUserQuestion in the main conversation thread. Questions target scope
+      ambiguities, edge cases, or missing constraints that would block the spec-agent.
+      There is no cap on the number of questions — eigen-change asks as many as genuinely
+      needed. However, eigen-change must only ask a question when the answer will actually
+      influence the spec or implementation; questions whose answers would not change anything
+      must be omitted to keep the conversation context clean. Phase 0 is always mandatory —
+      there is no skip flag or invocation argument to bypass it.
+    given: A user invokes /eigen-change with a feature description
+    when: Phase 0 runs before spec-agent is launched
+    then: |
+      eigen-change asks the user clarifying questions via AskUserQuestion — as many as
+      genuinely needed, but only questions whose answers will influence the spec or
+      implementation. Questions whose answers would not change the spec or plan are skipped.
+      The user's answers are collected and appended verbatim as "Shaping context" in the
+      spec-agent invocation prompt alongside the original feature description.
+  - id: AC-027
+    description: |
+      Phase 1b — Spec Review: after spec-agent writes and projects the spec (and before
+      the review UI poll begins), eigen-change reads the projected spec.yaml and identifies
+      concerns — edge cases, ambiguities, missing error handling, unclear acceptance criteria,
+      etc. Each concern is presented to the user as a separate, sequential AskUserQuestion.
+      The user addresses each concern in turn. After all concerns have been raised and
+      resolved, eigen-change enters the review UI poll. If the user's response to any concern
+      indicates a spec change is needed, the Spec Feedback Loop runs (spec-agent writes a new
+      change file, re-projects), and Phase 1b restarts from the beginning with the updated spec.
+    given: spec-agent has completed writing and projecting the spec
+    when: Phase 1b runs before the review UI poll
+    then: |
+      eigen-change reads the projected spec.yaml and derives a list of concerns. For each
+      concern, it calls AskUserQuestion with that single concern before moving to the next.
+      Only after every concern has been presented and the user has responded to each does
+      eigen-change enter the review UI poll. If any response triggers a spec revision, the
+      Spec Feedback Loop runs and Phase 1b repeats from scratch against the revised spec.
+      If no concerns are identified, eigen-change enters the review UI poll immediately.
+  - id: AC-028
+    description: |
+      Agent tool allowlists: every agent definition file (spec-agent.md, plan-agent.md,
+      compile-agent.md, review-agent.md) gains an explicit tools: field in its YAML
+      frontmatter listing only the tools that agent needs. spec-agent's allowlist includes
+      AskUserQuestion so it can ask clarifying questions of the user directly. plan-agent
+      and review-agent do not receive AskUserQuestion because they are read-only research
+      agents that return text to the caller rather than interacting with the user.
+      compile-agent does not receive AskUserQuestion; if ambiguous it stops and reports.
+    given: An agent definition file is deployed via eigen scaffold
+    when: The agent runs inside a subagent thread
+    then: |
+      The agent's frontmatter tools: field lists only the tools it needs. spec-agent's
+      list includes AskUserQuestion. plan-agent and review-agent do not have
+      AskUserQuestion. compile-agent does not have AskUserQuestion. The generated
+      .claude/agents/<name>.md copies match the embedded source files in
+      eigen/cmd/agents/<name>.md.
 dependencies: []
 technology:
   AgentTypes: spec-subagent, plan-subagent, compile-subagent
@@ -351,5 +420,5 @@ technology:
     Specs: changes/*.yaml + spec.yaml (eigen-spec format)
     Plans: temporary plan mode UI only (no file written)
     Code: git commits
-last_change: chg-015
-changes_count: 15
+last_change: chg-016
+changes_count: 16


### PR DESCRIPTION
## Summary

- Adds **Phase 0 — Shaping**: eigen-change now asks clarifying questions inline (via AskUserQuestion) before launching spec-agent, collecting answers as verbatim "Shaping context" passed to the spec prompt. Mandatory, no cap, no skip flag.
- Adds **Phase 1b — Spec Review**: after spec-agent writes the spec, eigen-change reviews it for concerns and presents each one as a sequential AskUserQuestion before opening the browser approval poll. Triggers the Spec Feedback Loop if any concern requires a spec change.
- Adds explicit `tools:` frontmatter allowlists to all four agent definition files. `spec-agent` now has `AskUserQuestion` available inside subagent threads; `plan-agent`, `compile-agent`, and `review-agent` do not.

## Spec
- `specs/ai-agent/skill-change/spec.yaml`
- ACs implemented: AC-026, AC-027, AC-028

## Test plan
- [ ] `go build ./...` from `eigen/` passes
- [ ] `eigen scaffold --force --no-hooks` regenerates `.claude/` copies correctly
- [ ] `.claude/agents/spec-agent.md` contains `AskUserQuestion` in `tools:`
- [ ] `.claude/skills/eigen-change/SKILL.md` contains `## Phase 0 — Shaping` and `### Phase 1b — Spec Review`
- [ ] `eigen spec validate ai-agent/skill-change` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)